### PR TITLE
(feat/0002_cpu-tests)  Add unit tests for addresing modes and memory

### DIFF
--- a/src/cpu/memory.rs
+++ b/src/cpu/memory.rs
@@ -35,3 +35,35 @@ impl Memory {
         self.write_u16(0xFFFC, 0x8000);
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_write_u16_correct_positions() {
+        let mut memory: Memory = Memory::new();
+
+        let address: u16 = 0x0000;
+        let value: u16 = 0x04D2;
+        let left: u8 = 0x04;
+        let right: u8 = 0xD2;
+
+        memory.write_u16(address, value);
+
+        assert_eq!(left, memory.memory[address as usize + 1]);
+        assert_eq!(right, memory.memory[address as usize]);
+    }
+
+    #[test]
+    fn test_read_write_u16() {
+        let mut memory: Memory = Memory::new();
+
+        let address: u16 = 0x0000;
+        let value: u16 = 0x04D2;
+
+        memory.write_u16(address, value);
+
+        assert_eq!(value, memory.read_u16(address));
+    }
+}


### PR DESCRIPTION
## Summary
Adding unit tests for:
Memory implementation
Addresing Modes functions

## Related Issue (link)
https://github.com/pcfim/nes-pcfim/issues/11

## Testing 
```
❯ cargo test
    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.06s
     Running unittests src/lib.rs (target/debug/deps/nes_pcfim-db9772defc09d3d1)

running 12 tests
test cpu::cpu_instructions::tests::test_get_operand_address_absolute ... ok
test cpu::cpu_instructions::tests::test_get_operand_address_absolute_x ... ok
test cpu::cpu_instructions::tests::test_get_operand_address_absolute_y ... ok
test cpu::cpu_instructions::tests::test_get_operand_address_indirect_y ... ok
test cpu::cpu_instructions::tests::test_get_operand_address_indirect_x ... ok
test cpu::memory::tests::test_read_write_u16 ... ok
test cpu::cpu_instructions::tests::test_zero_page_x ... ok
test cpu::cpu_instructions::tests::test_zero_page ... ok
test cpu::memory::tests::test_write_u16_correct_positions ... ok
test cpu::cpu_instructions::tests::test_zero_page_y ... ok
test cpu::cpu_instructions::tests::test_immediate ... ok
test cpu::cpu_instructions::tests::test_get_operand_address_none_addressing - should panic ... ok

test result: ok. 12 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running unittests src/main.rs (target/debug/deps/nes_pcfim-3fd9c6ed281c1f7f)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

   Doc-tests nes_pcfim

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

```