### PR TITLE
Adding operations codes for the set of instructions

### DIFF
--- a/.githooks/prepare-commit-msg
+++ b/.githooks/prepare-commit-msg
@@ -36,7 +36,7 @@ fi
 original_msg=$(cat "$commit_msg_file")
 
 # Create new message with branch name prefix
-new_msg="($branch_name) $original_msg"
+new_msg="$original_msg"
 
 # Write the new message back to the file
 echo "$new_msg" > "$commit_msg_file"

--- a/src/cpu/cpu_functions.rs
+++ b/src/cpu/cpu_functions.rs
@@ -104,39 +104,94 @@ fn compare(cpu: &mut CPU, mode: &AddressingMode, value_to_compare: u8) {
     }
 }
 
-// Function implementations for CPU instructions
+fn adding_with_carry(cpu: &mut CPU, value_to_add: u8) {
+    let carry = (cpu.status >> StatusBit::Carry as u8) & 1;
+    let sum = value_to_add as u16 + cpu.register_a as u16 + carry as u16;
+
+    let result: u8 = (sum & 0xFF) as u8;
+    let overflow_flag: u8 = (result ^ cpu.register_a) & (value_to_add ^ result) & 0x80;
+
+    // Result to accumulator
+    cpu.register_a = result;
+    // Setting flags
+    if overflow_flag != 0 {
+        update_status_bit(cpu, StatusBit::Overflow, BitwiseOperation::Set);
+    } else {
+        update_status_bit(cpu, StatusBit::Overflow, BitwiseOperation::Unset);
+    }
+    if sum > 0xff {
+        update_status_bit(cpu, StatusBit::Carry, BitwiseOperation::Set);
+    } else {
+        update_status_bit(cpu, StatusBit::Carry, BitwiseOperation::Unset);
+    }
+    update_zero_and_negative_flags(cpu, cpu.register_a);
+}
+
+pub fn increment_memory(cpu: &mut CPU, _mode: &AddressingMode) {
+    cpu.register_a = cpu.register_a.wrapping_add(1);
+    update_zero_and_negative_flags(cpu, cpu.register_a);
+}
 pub fn increment_x_register(cpu: &mut CPU, _mode: &AddressingMode) {
     cpu.register_x = cpu.register_x.wrapping_add(1);
     update_zero_and_negative_flags(cpu, cpu.register_x);
 }
+pub fn increment_y_register(cpu: &mut CPU, _mode: &AddressingMode) {
+    cpu.register_y = cpu.register_y.wrapping_add(1);
+    update_zero_and_negative_flags(cpu, cpu.register_y);
+}
 
-pub fn load_accumulator_a(cpu: &mut CPU, mode: &AddressingMode) {
+pub fn decrement_memory(cpu: &mut CPU, _mode: &AddressingMode) {
+    cpu.register_a = cpu.register_a.wrapping_sub(1);
+    update_zero_and_negative_flags(cpu, cpu.register_a);
+}
+pub fn decrement_x_register(cpu: &mut CPU, _mode: &AddressingMode) {
+    cpu.register_x = cpu.register_x.wrapping_sub(1);
+    update_zero_and_negative_flags(cpu, cpu.register_x);
+}
+pub fn decrement_y_register(cpu: &mut CPU, _mode: &AddressingMode) {
+    cpu.register_y = cpu.register_y.wrapping_sub(1);
+    update_zero_and_negative_flags(cpu, cpu.register_y);
+}
+
+pub fn load_accumulator(cpu: &mut CPU, mode: &AddressingMode) {
     let address = get_operand_address(cpu, mode);
     let value: u8 = cpu.memory.memory[address as usize];
     cpu.register_a = value;
     update_zero_and_negative_flags(cpu, cpu.register_a);
 }
-pub fn load_accumulator_x(cpu: &mut CPU, mode: &AddressingMode) {
+pub fn load_x_register(cpu: &mut CPU, mode: &AddressingMode) {
     let address = get_operand_address(cpu, mode);
     let value: u8 = cpu.memory.memory[address as usize];
     cpu.register_x = value;
-    update_zero_and_negative_flags(cpu, cpu.register_a);
+    update_zero_and_negative_flags(cpu, cpu.register_x);
 }
-pub fn load_accumulator_y(cpu: &mut CPU, mode: &AddressingMode) {
+pub fn load_y_register(cpu: &mut CPU, mode: &AddressingMode) {
     let address = get_operand_address(cpu, mode);
     let value: u8 = cpu.memory.memory[address as usize];
     cpu.register_y = value;
-    update_zero_and_negative_flags(cpu, cpu.register_a);
+    update_zero_and_negative_flags(cpu, cpu.register_y);
 }
 
 pub fn transfer_accumulator_to_x(cpu: &mut CPU, _mode: &AddressingMode) {
     cpu.register_x = cpu.register_a;
     update_zero_and_negative_flags(cpu, cpu.register_x);
 }
+pub fn transfer_accumulator_to_y(cpu: &mut CPU, _mode: &AddressingMode) {
+    cpu.register_y = cpu.register_a;
+    update_zero_and_negative_flags(cpu, cpu.register_y);
+}
 
 pub fn store_accumulator(cpu: &mut CPU, mode: &AddressingMode) {
     let address = get_operand_address(cpu, mode);
     cpu.memory.memory[address as usize] = cpu.register_a;
+}
+pub fn store_x_register(cpu: &mut CPU, mode: &AddressingMode) {
+    let address = get_operand_address(cpu, mode);
+    cpu.memory.memory[address as usize] = cpu.register_x;
+}
+pub fn store_y_register(cpu: &mut CPU, mode: &AddressingMode) {
+    let address = get_operand_address(cpu, mode);
+    cpu.memory.memory[address as usize] = cpu.register_y;
 }
 pub fn compare_a(cpu: &mut CPU, mode: &AddressingMode) {
     compare(cpu, mode, cpu.register_a);
@@ -147,6 +202,38 @@ pub fn compare_x(cpu: &mut CPU, mode: &AddressingMode) {
 pub fn compare_y(cpu: &mut CPU, mode: &AddressingMode) {
     compare(cpu, mode, cpu.register_y);
 }
+
+pub fn add_with_carry(cpu: &mut CPU, mode: &AddressingMode) {
+    let address = get_operand_address(cpu, mode);
+    let result: u8 = cpu.memory.memory[address as usize];
+    adding_with_carry(cpu, result);
+}
+
+pub fn substract_with_carry(cpu: &mut CPU, mode: &AddressingMode) {
+    let address = get_operand_address(cpu, mode);
+    let result: u8 = cpu.memory.memory[address as usize];
+    adding_with_carry(cpu, !result);
+}
+
+pub fn transfer_stack_pointer_to_x(cpu: &mut CPU, _mode: &AddressingMode) {
+    cpu.register_x = cpu.stack_pointer;
+    update_zero_and_negative_flags(cpu, cpu.register_x);
+}
+
+pub fn transfer_x_to_accumulator(cpu: &mut CPU, _mode: &AddressingMode) {
+    cpu.register_a = cpu.register_x;
+    update_zero_and_negative_flags(cpu, cpu.register_a);
+}
+
+pub fn transfer_y_to_accumulator(cpu: &mut CPU, _mode: &AddressingMode) {
+    cpu.register_a = cpu.register_y;
+    update_zero_and_negative_flags(cpu, cpu.register_a);
+}
+
+pub fn transfer_x_to_stack_pointer(cpu: &mut CPU, _mode: &AddressingMode) {
+    cpu.stack_pointer = cpu.register_x;
+}
+
 pub fn force_interruptions(_cpu: &mut CPU, _mode: &AddressingMode) {}
 
 #[cfg(test)]
@@ -154,6 +241,7 @@ mod tests {
     use super::*;
     use crate::cpu::addressing_mode::AddressingMode;
     use crate::cpu::cpu_functions;
+    use crate::cpu::cpu_model::STACK_RESET;
     use crate::cpu::memory::Memory;
 
     // Helper function to create a new CPU instance
@@ -170,8 +258,12 @@ mod tests {
             register_y: TEST_BASE_REGISTER_Y,
             status: TEST_BASE_STATUS,
             program_counter: TEST_BASE_PROGRAM_COUNTER,
+            stack_pointer: STACK_RESET,
             memory: Memory::new(),
         }
+    }
+    fn get_bit(current_byte: u8, status_bit: StatusBit) -> u8 {
+        (current_byte >> (status_bit as u8)) & 1
     }
     #[test]
     fn test_immediate() {
@@ -304,11 +396,69 @@ mod tests {
     // Tests for the functions themselves
 
     #[test]
-    fn test_increment_x_register_by_1() {
+    fn test_increment_memory() {
         let mut cpu: CPU = create_test_cpu();
         let mode: AddressingMode = AddressingMode::Immediate;
-        increment_x_register(&mut cpu, &mode);
-        assert_eq!(cpu.register_x, TEST_BASE_REGISTER_X + 1);
+        const AMOUNT: u8 = 20;
+        for _ in 0..AMOUNT {
+            increment_memory(&mut cpu, &mode);
+        }
+        assert_eq!(cpu.register_a, TEST_BASE_REGISTER_A.wrapping_add(AMOUNT));
+    }
+
+    #[test]
+    fn test_increment_x_register() {
+        let mut cpu: CPU = create_test_cpu();
+        let mode: AddressingMode = AddressingMode::Immediate;
+        const AMOUNT: u8 = 20;
+        for _ in 0..AMOUNT {
+            increment_x_register(&mut cpu, &mode);
+        }
+        assert_eq!(cpu.register_x, TEST_BASE_REGISTER_X.wrapping_add(AMOUNT));
+    }
+
+    #[test]
+    fn test_increment_y_register() {
+        let mut cpu: CPU = create_test_cpu();
+        let mode: AddressingMode = AddressingMode::Immediate;
+        const AMOUNT: u8 = 20;
+        for _ in 0..AMOUNT {
+            increment_y_register(&mut cpu, &mode);
+        }
+        assert_eq!(cpu.register_y, TEST_BASE_REGISTER_Y.wrapping_add(AMOUNT));
+    }
+
+    #[test]
+    fn test_decrement_memory() {
+        let mut cpu: CPU = create_test_cpu();
+        let mode: AddressingMode = AddressingMode::Immediate;
+        const AMOUNT: u8 = 20;
+        for _ in 0..AMOUNT {
+            decrement_memory(&mut cpu, &mode);
+        }
+        assert_eq!(cpu.register_a, TEST_BASE_REGISTER_A.wrapping_sub(AMOUNT));
+    }
+
+    #[test]
+    fn test_decrement_x_register() {
+        let mut cpu: CPU = create_test_cpu();
+        let mode: AddressingMode = AddressingMode::Immediate;
+        const AMOUNT: u8 = 20;
+        for _ in 0..AMOUNT {
+            decrement_x_register(&mut cpu, &mode);
+        }
+        assert_eq!(cpu.register_x, TEST_BASE_REGISTER_X.wrapping_sub(AMOUNT));
+    }
+
+    #[test]
+    fn test_decrement_y_register() {
+        let mut cpu: CPU = create_test_cpu();
+        let mode: AddressingMode = AddressingMode::Immediate;
+        const AMOUNT: u8 = 20;
+        for _ in 0..AMOUNT {
+            decrement_y_register(&mut cpu, &mode);
+        }
+        assert_eq!(cpu.register_y, TEST_BASE_REGISTER_Y.wrapping_sub(AMOUNT));
     }
 
     #[test]
@@ -320,11 +470,13 @@ mod tests {
         let data_to_load: u8 = 0xff;
         cpu.memory.memory[SAFE_MEMORY_ADDRESS as usize] = data_to_load;
 
-        load_accumulator_a(&mut cpu, &AddressingMode::Absolute);
+        load_accumulator(&mut cpu, &AddressingMode::Absolute);
         assert_eq!(cpu.register_a, data_to_load);
-        load_accumulator_x(&mut cpu, &AddressingMode::Absolute);
+
+        load_x_register(&mut cpu, &AddressingMode::Absolute);
         assert_eq!(cpu.register_x, data_to_load);
-        load_accumulator_y(&mut cpu, &AddressingMode::Absolute);
+
+        load_y_register(&mut cpu, &AddressingMode::Absolute);
         assert_eq!(cpu.register_y, data_to_load);
     }
 
@@ -336,6 +488,41 @@ mod tests {
     }
 
     #[test]
+    fn test_transfer_accumulator_to_y() {
+        let mut cpu: CPU = create_test_cpu();
+        transfer_accumulator_to_y(&mut cpu, &AddressingMode::NoneAddressing);
+        assert_eq!(cpu.register_y, TEST_BASE_REGISTER_A);
+    }
+
+    #[test]
+    fn test_transfer_x_to_accumulator() {
+        let mut cpu: CPU = create_test_cpu();
+        transfer_x_to_accumulator(&mut cpu, &AddressingMode::NoneAddressing);
+        assert_eq!(cpu.register_a, TEST_BASE_REGISTER_X);
+    }
+
+    #[test]
+    fn test_transfer_y_to_accumulator() {
+        let mut cpu: CPU = create_test_cpu();
+        transfer_y_to_accumulator(&mut cpu, &AddressingMode::NoneAddressing);
+        assert_eq!(cpu.register_a, TEST_BASE_REGISTER_Y);
+    }
+
+    #[test]
+    fn test_transfer_stack_pointer_to_x() {
+        let mut cpu: CPU = create_test_cpu();
+        transfer_stack_pointer_to_x(&mut cpu, &AddressingMode::NoneAddressing);
+        assert_eq!(cpu.register_x, STACK_RESET);
+    }
+
+    #[test]
+    fn test_transfer_x_to_stack_pointer() {
+        let mut cpu: CPU = create_test_cpu();
+        transfer_x_to_stack_pointer(&mut cpu, &AddressingMode::NoneAddressing);
+        assert_eq!(cpu.stack_pointer, TEST_BASE_REGISTER_X);
+    }
+
+    #[test]
     fn test_store_accumulator() {
         let mut cpu: CPU = create_test_cpu();
         cpu.memory
@@ -343,6 +530,26 @@ mod tests {
         store_accumulator(&mut cpu, &AddressingMode::Absolute);
         let value_stored = cpu.memory.memory[SAFE_MEMORY_ADDRESS as usize];
         assert_eq!(value_stored, TEST_BASE_REGISTER_A);
+    }
+
+    #[test]
+    fn test_store_x_register() {
+        let mut cpu: CPU = create_test_cpu();
+        cpu.memory
+            .write_u16(TEST_BASE_PROGRAM_COUNTER, SAFE_MEMORY_ADDRESS);
+        store_x_register(&mut cpu, &AddressingMode::Absolute);
+        let value_stored = cpu.memory.memory[SAFE_MEMORY_ADDRESS as usize];
+        assert_eq!(value_stored, TEST_BASE_REGISTER_X);
+    }
+
+    #[test]
+    fn test_store_y_register() {
+        let mut cpu: CPU = create_test_cpu();
+        cpu.memory
+            .write_u16(TEST_BASE_PROGRAM_COUNTER, SAFE_MEMORY_ADDRESS);
+        store_y_register(&mut cpu, &AddressingMode::Absolute);
+        let value_stored = cpu.memory.memory[SAFE_MEMORY_ADDRESS as usize];
+        assert_eq!(value_stored, TEST_BASE_REGISTER_Y);
     }
 
     #[test]
@@ -369,5 +576,104 @@ mod tests {
         compare(&mut cpu, &AddressingMode::Immediate, 0x7f);
         let status: u8 = cpu.status;
         assert_eq!(status, 0x80);
+    }
+    type AddOrSubstractWithCarryTests = (u8, u8, bool, u8, u8, u8, u8, u8);
+    fn generate_tests_add_with_carry() -> Vec<AddOrSubstractWithCarryTests> {
+        // accum_init, memory, carry_initial,
+        // C, Z, N, V
+        let lst: Vec<AddOrSubstractWithCarryTests> = vec![
+            (0x60, 0x70, false, 0xd0, 0, 0, 1, 1),
+            (0x7F, 0x01, false, 0x80, 0, 0, 1, 1),
+            (0x80, 0xFF, false, 0x7F, 1, 0, 0, 1),
+            // Sign change positive to negative with overflow (0x7F + 0x01 = 0x80)
+            (0x7F, 0x01, false, 0x80, 0, 0, 1, 1),
+            // Sign change negative to positive with overflow and carry (0x80 + 0xFF = 0x7F with carry)
+            (0x80, 0xFF, false, 0x7F, 1, 0, 0, 1),
+            // Carry generation without overflow (0xFF + 0x01 = 0x00 with carry)
+            (0xFF, 0x01, false, 0x00, 1, 1, 0, 0),
+            // Complex case with carry-in (0x80 + 0x80 + 1 = 0x01 with carry)
+            (0x80, 0x80, true, 0x01, 1, 0, 0, 1),
+            // Zero result with carry-in (0xFF + 0x00 + 1 = 0x00 with carry)
+            (0xFF, 0x00, true, 0x00, 1, 1, 0, 0),
+            (0x80, 0x80, true, 0x01, 1, 0, 0, 1),
+        ];
+        lst
+    }
+
+    fn generate_tests_substract_with_carry() -> Vec<AddOrSubstractWithCarryTests> {
+        // accum_init, memory, carry_initial,
+        // C, Z, N, V
+        let lst: Vec<AddOrSubstractWithCarryTests> = vec![
+            (0x05, 0x01, false, 0x03, 1, 0, 0, 0),
+            (0x00, 0x01, true, 0xff, 0, 0, 1, 0),
+            (0x7f, 0xff, true, 0x80, 0, 0, 1, 1),
+            (0x40, 0xc0, true, 0x80, 0, 0, 1, 1),
+            (0x50, 0x60, true, 0xf0, 0, 0, 1, 0),
+            // Sign change negative to positive with overflow (0x80 - 0x01 = 0x7F)
+            (0x80, 0x01, true, 0x7F, 1, 0, 0, 1),
+            // Borrow generation (0x00 - 0x01 = 0xFF with borrow)
+            (0x00, 0x01, true, 0xFF, 0, 0, 1, 0),
+            // Sign change positive to negative with overflow (0x7F - 0xFF = 0x80)
+            (0x7F, 0xFF, true, 0x80, 0, 0, 1, 1),
+            // Zero result (0x01 - 0x01 = 0x00 without borrow)
+            (0x01, 0x01, true, 0x00, 1, 1, 0, 0),
+            // Borrow-in affects result (0x00 - 0x00 with borrow-in = 0xFF)
+            (0x00, 0x00, false, 0xFF, 0, 0, 1, 0),
+            (0x80, 0x7F, false, 0x00, 1, 1, 0, 1),
+        ];
+        lst
+    }
+    #[test]
+    fn testing_add_with_carry() {
+        for testing_parameters in generate_tests_add_with_carry() {
+            let mut cpu: CPU = create_test_cpu();
+            cpu.register_a = testing_parameters.0;
+            cpu.memory.memory[TEST_BASE_PROGRAM_COUNTER as usize] = testing_parameters.1;
+            if testing_parameters.2 {
+                update_status_bit(&mut cpu, StatusBit::Carry, BitwiseOperation::Set);
+            } else {
+                update_status_bit(&mut cpu, StatusBit::Carry, BitwiseOperation::Unset);
+            }
+            add_with_carry(&mut cpu, &AddressingMode::Immediate);
+            // Summing 0x60 + 0x50
+            assert_eq!(cpu.register_a, testing_parameters.3);
+            assert_eq!(get_bit(cpu.status, StatusBit::Carry), testing_parameters.4);
+            assert_eq!(get_bit(cpu.status, StatusBit::Zero), testing_parameters.5);
+            assert_eq!(
+                get_bit(cpu.status, StatusBit::Negative),
+                testing_parameters.6
+            );
+            assert_eq!(
+                get_bit(cpu.status, StatusBit::Overflow),
+                testing_parameters.7
+            );
+        }
+    }
+
+    #[test]
+    fn testing_substract_with_carry() {
+        for testing_parameters in generate_tests_substract_with_carry() {
+            let mut cpu: CPU = create_test_cpu();
+            cpu.register_a = testing_parameters.0;
+            cpu.memory.memory[TEST_BASE_PROGRAM_COUNTER as usize] = testing_parameters.1;
+            if testing_parameters.2 {
+                update_status_bit(&mut cpu, StatusBit::Carry, BitwiseOperation::Set);
+            } else {
+                update_status_bit(&mut cpu, StatusBit::Carry, BitwiseOperation::Unset);
+            }
+            substract_with_carry(&mut cpu, &AddressingMode::Immediate);
+            // Summing 0x60 + 0x50
+            assert_eq!(cpu.register_a, testing_parameters.3);
+            assert_eq!(get_bit(cpu.status, StatusBit::Carry), testing_parameters.4);
+            assert_eq!(get_bit(cpu.status, StatusBit::Zero), testing_parameters.5);
+            assert_eq!(
+                get_bit(cpu.status, StatusBit::Negative),
+                testing_parameters.6
+            );
+            assert_eq!(
+                get_bit(cpu.status, StatusBit::Overflow),
+                testing_parameters.7
+            );
+        }
     }
 }

--- a/src/cpu/cpu_instructions.rs
+++ b/src/cpu/cpu_instructions.rs
@@ -1,6 +1,7 @@
 use super::operation_codes;
 use crate::cpu::cpu_model::ExecuteFunction;
 use crate::cpu::cpu_model::CPU;
+use crate::cpu::cpu_model::STACK_RESET;
 use crate::cpu::memory::Memory;
 use std::collections::HashMap;
 
@@ -17,6 +18,7 @@ impl CPU {
             register_x: 0,
             register_y: 0,
             status: 0,
+            stack_pointer: STACK_RESET,
             program_counter: 0,
             memory: Memory::new(),
         }

--- a/src/cpu/cpu_model.rs
+++ b/src/cpu/cpu_model.rs
@@ -1,11 +1,14 @@
 use crate::cpu::addressing_mode::AddressingMode;
 use crate::cpu::memory::Memory;
 pub type ExecuteFunction = fn(&mut CPU, &AddressingMode);
+pub const STACK: u16 = 0x0100;
+pub const STACK_RESET: u8 = 0xfd;
 pub struct CPU {
     pub register_a: u8,
     pub register_x: u8,
     pub register_y: u8,
     pub status: u8,
     pub program_counter: u16,
+    pub stack_pointer: u8,
     pub memory: Memory,
 }

--- a/src/cpu/operation_codes.rs
+++ b/src/cpu/operation_codes.rs
@@ -5,26 +5,30 @@ use lazy_static::lazy_static;
 use std::collections::HashMap;
 
 pub enum OperationName {
-    ForceInterrupt,
-    TransferAccumulatorToX,
-    TransferAccumulatorToY,
-    LoadAccumulator,
-    LoadAccumulatorX,
-    LoadAccumulatorY,
-    StoreAccumulator,
-    StoreAccumulatorX,
-    StoreAccumulatorY,
-    IncrementMemory,
-    IncrementXRegister,
-    IncrementYRegister,
+    AddWithCarry,
+    Compare,
+    CompareX,
+    CompareY,
     DecrementMemory,
     DecrementXRegister,
     DecrementYRegister,
-    CompareX,
-    CompareY,
-    Compare,
-    AddWithCarry,
+    ForceInterrupt,
+    IncrementMemory,
+    IncrementXRegister,
+    IncrementYRegister,
+    LoadAccumulator,
+    LoadXRegister,
+    LoadYRegister,
     SubstractWithCarry,
+    StoreAccumulator,
+    StoreXRegister,
+    StoreYRegister,
+    TransferAccumulatorToX,
+    TransferAccumulatorToY,
+    TransferStackPointerToX,
+    TransferXToAccumulator,
+    TransferXToStackPointer,
+    TransferYToAccumulator,
 }
 
 pub struct Operation {
@@ -72,12 +76,12 @@ lazy_static! {
         OperationCodes::new(
             OperationName::TransferAccumulatorToX,
             vec![Operation::new(0xaa, 1, 2, AddressingMode::NoneAddressing)],
-            cpu_functions::force_interruptions
+            cpu_functions::transfer_accumulator_to_x
         ),
         OperationCodes::new(
             OperationName::TransferAccumulatorToY,
             vec![Operation::new(0xaa, 1, 2, AddressingMode::NoneAddressing)],
-            cpu_functions::force_interruptions
+            cpu_functions::transfer_accumulator_to_y
         ),
         OperationCodes::new(
             OperationName::IncrementXRegister,
@@ -87,7 +91,7 @@ lazy_static! {
         OperationCodes::new(
             OperationName::IncrementYRegister,
             vec![Operation::new(0xc8, 1, 2, AddressingMode::NoneAddressing)],
-            cpu_functions::force_interruptions
+            cpu_functions::increment_y_register
         ),
         OperationCodes::new(
             OperationName::IncrementMemory,
@@ -97,17 +101,17 @@ lazy_static! {
                 Operation::new(0xee, 3, 6, AddressingMode::Absolute),
                 Operation::new(0xfe, 3, 7, AddressingMode::Absolute_X),
             ],
-            cpu_functions::force_interruptions
+            cpu_functions::increment_memory
         ),
         OperationCodes::new(
             OperationName::DecrementXRegister,
             vec![Operation::new(0xca, 1, 2, AddressingMode::NoneAddressing)],
-            cpu_functions::increment_x_register
+            cpu_functions::decrement_x_register
         ),
         OperationCodes::new(
             OperationName::DecrementYRegister,
             vec![Operation::new(0x88, 1, 2, AddressingMode::NoneAddressing)],
-            cpu_functions::force_interruptions
+            cpu_functions::decrement_y_register
         ),
         OperationCodes::new(
             OperationName::DecrementMemory,
@@ -117,7 +121,7 @@ lazy_static! {
                 Operation::new(0xce, 3, 6, AddressingMode::Absolute),
                 Operation::new(0xde, 3, 7, AddressingMode::Absolute_X),
             ],
-            cpu_functions::force_interruptions
+            cpu_functions::decrement_memory
         ),
         OperationCodes::new(
             OperationName::LoadAccumulator,
@@ -131,10 +135,10 @@ lazy_static! {
                 Operation::new(0xa1, 2, 6, AddressingMode::Indirect_X),
                 Operation::new(0xb1, 2, 5, AddressingMode::Indirect_Y),
             ],
-            cpu_functions::load_accumulator_a
+            cpu_functions::load_accumulator
         ),
         OperationCodes::new(
-            OperationName::LoadAccumulatorX,
+            OperationName::LoadXRegister,
             vec![
                 Operation::new(0xA2, 2, 2, AddressingMode::Immediate),
                 Operation::new(0xA6, 2, 3, AddressingMode::ZeroPage),
@@ -142,10 +146,10 @@ lazy_static! {
                 Operation::new(0xAE, 3, 4, AddressingMode::Absolute),
                 Operation::new(0xBE, 3, 4, AddressingMode::Absolute_Y),
             ],
-            cpu_functions::load_accumulator_x
+            cpu_functions::load_x_register
         ),
         OperationCodes::new(
-            OperationName::LoadAccumulatorY,
+            OperationName::LoadYRegister,
             vec![
                 Operation::new(0xA0, 2, 2, AddressingMode::Immediate),
                 Operation::new(0xA4, 2, 3, AddressingMode::ZeroPage),
@@ -153,7 +157,7 @@ lazy_static! {
                 Operation::new(0xAC, 3, 4, AddressingMode::Absolute),
                 Operation::new(0xBC, 3, 4, AddressingMode::Absolute_X),
             ],
-            cpu_functions::load_accumulator_y
+            cpu_functions::load_y_register
         ),
         OperationCodes::new(
             OperationName::StoreAccumulator,
@@ -169,22 +173,22 @@ lazy_static! {
             cpu_functions::store_accumulator
         ),
         OperationCodes::new(
-            OperationName::StoreAccumulatorX,
+            OperationName::StoreXRegister,
             vec![
                 Operation::new(0x86, 2, 3, AddressingMode::ZeroPage),
                 Operation::new(0x96, 2, 4, AddressingMode::ZeroPage_Y),
                 Operation::new(0x8e, 3, 4, AddressingMode::Absolute),
             ],
-            cpu_functions::force_interruptions
+            cpu_functions::store_x_register
         ),
         OperationCodes::new(
-            OperationName::StoreAccumulatorY,
+            OperationName::StoreYRegister,
             vec![
                 Operation::new(0x84, 2, 3, AddressingMode::ZeroPage),
                 Operation::new(0x94, 2, 4, AddressingMode::ZeroPage_X),
                 Operation::new(0x8c, 3, 4, AddressingMode::Absolute),
             ],
-            cpu_functions::force_interruptions
+            cpu_functions::store_y_register
         ),
         OperationCodes::new(
             OperationName::Compare,
@@ -230,7 +234,7 @@ lazy_static! {
                 Operation::new(0x61, 2, 6, AddressingMode::Indirect_X),
                 Operation::new(0x71, 2, 5, AddressingMode::Indirect_Y)
             ],
-            cpu_functions::force_interruptions
+            cpu_functions::add_with_carry
         ),
         OperationCodes::new(
             OperationName::SubstractWithCarry,
@@ -244,22 +248,28 @@ lazy_static! {
                 Operation::new(0xe1, 2, 6, AddressingMode::Indirect_X),
                 Operation::new(0xf1, 2, 5, AddressingMode::Indirect_Y),
             ],
-            cpu_functions::force_interruptions
+            cpu_functions::substract_with_carry
         ),
         OperationCodes::new(
-            OperationName::SubstractWithCarry,
-            vec![
-                Operation::new(0xe9, 2, 2, AddressingMode::Immediate),
-                Operation::new(0xe5, 2, 3, AddressingMode::ZeroPage),
-                Operation::new(0xf5, 2, 4, AddressingMode::ZeroPage_X),
-                Operation::new(0xed, 3, 4, AddressingMode::Absolute),
-                Operation::new(0xfd, 3, 4, AddressingMode::Absolute_X),
-                Operation::new(0xf9, 3, 4, AddressingMode::Absolute_Y),
-                Operation::new(0xe1, 2, 6, AddressingMode::Indirect_X),
-                Operation::new(0xf1, 2, 5, AddressingMode::Indirect_Y),
-            ],
-            cpu_functions::force_interruptions
+            OperationName::TransferStackPointerToX,
+            vec![Operation::new(0xba, 1, 2, AddressingMode::NoneAddressing),],
+            cpu_functions::transfer_stack_pointer_to_x
         ),
+        OperationCodes::new(
+            OperationName::TransferXToAccumulator,
+            vec![Operation::new(0x8a, 1, 2, AddressingMode::NoneAddressing),],
+            cpu_functions::transfer_x_to_accumulator
+        ),
+        OperationCodes::new(
+            OperationName::TransferXToStackPointer,
+            vec![Operation::new(0x9a, 1, 2, AddressingMode::NoneAddressing),],
+            cpu_functions::transfer_x_to_stack_pointer
+        ),
+        OperationCodes::new(
+            OperationName::TransferYToAccumulator,
+            vec![Operation::new(0x98, 1, 2, AddressingMode::NoneAddressing),],
+            cpu_functions::transfer_y_to_accumulator
+        )
     ];
     pub static ref OPERATION_CODES_MAP: HashMap<u8, (&'static Operation, ExecuteFunction)> = {
         let mut map = HashMap::new();


### PR DESCRIPTION
## Summary
<!-- Provide a short summary of the changes made -->
This PR covers two changes:
- Adds operation codes for some functions
- For a reduced set of functions (load_accumulator) adds related instruction function and updates tests
- Extracting constants in the functions unit tests 
## Related Issue (link)
<!-- If applicable, reference the issue number (e.g., Fixes #123) -->
https://github.com/pcfim/nes-pcfim/issues/22
## Testing 
<!-- Put the commands/methods used for testing this change -->
cargo test
## Additional Notes
<!-- Any other relevant information -->