### PR TITLE
(feat/0024_Add-Branch-Operations) Add branch operations

### DIFF
--- a/src/cpu/addressing_mode.rs
+++ b/src/cpu/addressing_mode.rs
@@ -10,5 +10,6 @@ pub enum AddressingMode {
     Absolute_Y,
     Indirect_X,
     Indirect_Y,
+    Relative,
     NoneAddressing,
 }

--- a/src/cpu/cpu_functions.rs
+++ b/src/cpu/cpu_functions.rs
@@ -156,43 +156,59 @@ pub fn decrement_y_register(cpu: &mut CPU, _mode: &AddressingMode) {
     update_zero_and_negative_flags(cpu, cpu.register_y);
 }
 
-fn branch(cpu: &mut CPU, condition: bool) {
+fn branch(cpu: &mut CPU, mode: &AddressingMode, condition: bool) {
     if condition {
-        let offset = cpu.memory.memory[cpu.program_counter as usize] as i8;
-        cpu.program_counter = cpu.program_counter.wrapping_add(offset as u16);
+        let target_address = get_operand_address(cpu, mode);
+        cpu.program_counter = target_address;
     }
 }
 
-pub fn branch_if_carry_clear(cpu: &mut CPU, _mode: &AddressingMode) {
-    branch(cpu, cpu.status & (1 << (StatusBit::Carry as u8)) == 0);
+pub fn branch_if_carry_clear(cpu: &mut CPU, mode: &AddressingMode) {
+    branch(cpu, mode, cpu.status & (1 << (StatusBit::Carry as u8)) == 0);
 }
 
-pub fn branch_if_carry_set(cpu: &mut CPU, _mode: &AddressingMode) {
-    branch(cpu, cpu.status & (1 << (StatusBit::Carry as u8)) != 0);
+pub fn branch_if_carry_set(cpu: &mut CPU, mode: &AddressingMode) {
+    branch(cpu, mode, cpu.status & (1 << (StatusBit::Carry as u8)) != 0);
 }
 
-pub fn branch_if_equal(cpu: &mut CPU, _mode: &AddressingMode) {
-    branch(cpu, cpu.status & (1 << (StatusBit::Zero as u8)) != 0);
+pub fn branch_if_equal(cpu: &mut CPU, mode: &AddressingMode) {
+    branch(cpu, mode, cpu.status & (1 << (StatusBit::Zero as u8)) != 0);
 }
 
-pub fn branch_if_minus(cpu: &mut CPU, _mode: &AddressingMode) {
-    branch(cpu, cpu.status & (1 << (StatusBit::Negative as u8)) != 0);
+pub fn branch_if_minus(cpu: &mut CPU, mode: &AddressingMode) {
+    branch(
+        cpu,
+        mode,
+        cpu.status & (1 << (StatusBit::Negative as u8)) != 0,
+    );
 }
 
-pub fn branch_if_not_equal(cpu: &mut CPU, _mode: &AddressingMode) {
-    branch(cpu, cpu.status & (1 << (StatusBit::Zero as u8)) == 0);
+pub fn branch_if_not_equal(cpu: &mut CPU, mode: &AddressingMode) {
+    branch(cpu, mode, cpu.status & (1 << (StatusBit::Zero as u8)) == 0);
 }
 
-pub fn branch_if_positive(cpu: &mut CPU, _mode: &AddressingMode) {
-    branch(cpu, cpu.status & (1 << (StatusBit::Negative as u8)) == 0);
+pub fn branch_if_positive(cpu: &mut CPU, mode: &AddressingMode) {
+    branch(
+        cpu,
+        mode,
+        cpu.status & (1 << (StatusBit::Negative as u8)) == 0,
+    );
 }
 
-pub fn branch_if_overflow_clear(cpu: &mut CPU, _mode: &AddressingMode) {
-    branch(cpu, cpu.status & (1 << (StatusBit::Overflow as u8)) == 0);
+pub fn branch_if_overflow_clear(cpu: &mut CPU, mode: &AddressingMode) {
+    branch(
+        cpu,
+        mode,
+        cpu.status & (1 << (StatusBit::Overflow as u8)) == 0,
+    );
 }
 
-pub fn branch_if_overflow_set(cpu: &mut CPU, _mode: &AddressingMode) {
-    branch(cpu, cpu.status & (1 << (StatusBit::Overflow as u8)) != 0);
+pub fn branch_if_overflow_set(cpu: &mut CPU, mode: &AddressingMode) {
+    branch(
+        cpu,
+        mode,
+        cpu.status & (1 << (StatusBit::Overflow as u8)) != 0,
+    );
 }
 
 pub fn load_accumulator(cpu: &mut CPU, mode: &AddressingMode) {
@@ -364,8 +380,7 @@ mod tests {
         cpu.program_counter = 0x2000;
         cpu.memory.memory[cpu.program_counter as usize] = 0x05;
         let mode: AddressingMode = AddressingMode::Relative;
-        let effective_address: u16 = cpu_functions::get_operand_address(&mut cpu, &mode);
-        assert_eq!(effective_address, 0x2006);
+        assert_eq!(cpu_functions::get_operand_address(&mut cpu, &mode), 0x2006);
     }
 
     #[test]
@@ -374,8 +389,7 @@ mod tests {
         cpu.program_counter = 0x2000;
         cpu.memory.memory[cpu.program_counter as usize] = 0xFB;
         let mode: AddressingMode = AddressingMode::Relative;
-        let effective_address: u16 = cpu_functions::get_operand_address(&mut cpu, &mode);
-        assert_eq!(effective_address, 0x1FFC);
+        assert_eq!(cpu_functions::get_operand_address(&mut cpu, &mode), 0x1FFC);
     }
 
     #[test]
@@ -695,7 +709,10 @@ mod tests {
         cpu.program_counter = 0x1000;
         cpu.memory.memory[cpu.program_counter as usize] = 5;
         cpu_functions::branch_if_carry_clear(&mut cpu, &AddressingMode::Relative);
-        assert_eq!(cpu.program_counter, 0x1000u16.wrapping_add(5));
+        assert_eq!(
+            cpu.program_counter,
+            0x1000u16.wrapping_add(1).wrapping_add(5)
+        );
     }
 
     #[test]
@@ -717,7 +734,10 @@ mod tests {
         cpu.program_counter = 0x1000;
         cpu.memory.memory[cpu.program_counter as usize] = 5;
         cpu_functions::branch_if_carry_set(&mut cpu, &AddressingMode::Relative);
-        assert_eq!(cpu.program_counter, 0x1000u16.wrapping_add(5));
+        assert_eq!(
+            cpu.program_counter,
+            0x1000u16.wrapping_add(1).wrapping_add(5)
+        );
     }
 
     #[test]
@@ -739,7 +759,10 @@ mod tests {
         cpu.program_counter = 0x1000;
         cpu.memory.memory[cpu.program_counter as usize] = 5;
         cpu_functions::branch_if_equal(&mut cpu, &AddressingMode::Relative);
-        assert_eq!(cpu.program_counter, 0x1000u16.wrapping_add(5));
+        assert_eq!(
+            cpu.program_counter,
+            0x1000u16.wrapping_add(1).wrapping_add(5)
+        );
     }
 
     #[test]
@@ -761,7 +784,10 @@ mod tests {
         cpu.program_counter = 0x1000;
         cpu.memory.memory[cpu.program_counter as usize] = 5;
         cpu_functions::branch_if_minus(&mut cpu, &AddressingMode::Relative);
-        assert_eq!(cpu.program_counter, 0x1000u16.wrapping_add(5));
+        assert_eq!(
+            cpu.program_counter,
+            0x1000u16.wrapping_add(1).wrapping_add(5)
+        );
     }
 
     #[test]
@@ -783,7 +809,10 @@ mod tests {
         cpu.program_counter = 0x1000;
         cpu.memory.memory[cpu.program_counter as usize] = 5;
         cpu_functions::branch_if_not_equal(&mut cpu, &AddressingMode::Relative);
-        assert_eq!(cpu.program_counter, 0x1000u16.wrapping_add(5));
+        assert_eq!(
+            cpu.program_counter,
+            0x1000u16.wrapping_add(1).wrapping_add(5)
+        );
     }
 
     #[test]
@@ -805,7 +834,10 @@ mod tests {
         cpu.program_counter = 0x1000;
         cpu.memory.memory[cpu.program_counter as usize] = 5;
         cpu_functions::branch_if_positive(&mut cpu, &AddressingMode::Relative);
-        assert_eq!(cpu.program_counter, 0x1000u16.wrapping_add(5));
+        assert_eq!(
+            cpu.program_counter,
+            0x1000u16.wrapping_add(1).wrapping_add(5)
+        );
     }
 
     #[test]
@@ -827,7 +859,10 @@ mod tests {
         cpu.program_counter = 0x1000;
         cpu.memory.memory[cpu.program_counter as usize] = 5;
         cpu_functions::branch_if_overflow_clear(&mut cpu, &AddressingMode::Relative);
-        assert_eq!(cpu.program_counter, 0x1000u16.wrapping_add(5));
+        assert_eq!(
+            cpu.program_counter,
+            0x1000u16.wrapping_add(1).wrapping_add(5)
+        );
     }
 
     #[test]
@@ -849,7 +884,10 @@ mod tests {
         cpu.program_counter = 0x1000;
         cpu.memory.memory[cpu.program_counter as usize] = 5;
         cpu_functions::branch_if_overflow_set(&mut cpu, &AddressingMode::Relative);
-        assert_eq!(cpu.program_counter, 0x1000u16.wrapping_add(5));
+        assert_eq!(
+            cpu.program_counter,
+            0x1000u16.wrapping_add(1).wrapping_add(5)
+        );
     }
 
     #[test]

--- a/src/cpu/operation_codes.rs
+++ b/src/cpu/operation_codes.rs
@@ -5,6 +5,14 @@ use lazy_static::lazy_static;
 use std::collections::HashMap;
 
 pub enum OperationName {
+    BranchIfCarryClear,
+    BranchIfCarrySet,
+    BranchIfEqual,
+    BranchIfMinus,
+    BranchIfNotEqual,
+    BranchIfPositive,
+    BranchIfOverflowClear,
+    BranchIfOverflowSet,
     ForceInterrupt,
     TransferAccumulatorToX,
     LoadAccumulator,
@@ -52,6 +60,46 @@ impl OperationCodes {
 
 lazy_static! {
     pub static ref CPU_OPS_CODES: Vec<OperationCodes> = vec![
+        OperationCodes::new(
+            OperationName::BranchIfCarryClear,
+            vec![Operation::new(0x90, 2, 2, AddressingMode::Relative),],
+            cpu_functions::branch_if_carry_clear
+        ),
+        OperationCodes::new(
+            OperationName::BranchIfCarrySet,
+            vec![Operation::new(0xb0, 2, 2, AddressingMode::Relative),],
+            cpu_functions::branch_if_carry_set
+        ),
+        OperationCodes::new(
+            OperationName::BranchIfEqual,
+            vec![Operation::new(0xf0, 2, 2, AddressingMode::Relative),],
+            cpu_functions::branch_if_equal
+        ),
+        OperationCodes::new(
+            OperationName::BranchIfMinus,
+            vec![Operation::new(0x30, 2, 2, AddressingMode::Relative),],
+            cpu_functions::branch_if_minus
+        ),
+        OperationCodes::new(
+            OperationName::BranchIfNotEqual,
+            vec![Operation::new(0xd0, 2, 2, AddressingMode::Relative),],
+            cpu_functions::branch_if_not_equal
+        ),
+        OperationCodes::new(
+            OperationName::BranchIfPositive,
+            vec![Operation::new(0x10, 2, 2, AddressingMode::Relative),],
+            cpu_functions::branch_if_positive
+        ),
+        OperationCodes::new(
+            OperationName::BranchIfOverflowClear,
+            vec![Operation::new(0x50, 2, 2, AddressingMode::Relative),],
+            cpu_functions::branch_if_overflow_clear
+        ),
+        OperationCodes::new(
+            OperationName::BranchIfOverflowSet,
+            vec![Operation::new(0x70, 2, 2, AddressingMode::Relative),],
+            cpu_functions::branch_if_overflow_set
+        ),
         OperationCodes::new(
             OperationName::ForceInterrupt,
             vec![Operation::new(0x00, 1, 7, AddressingMode::NoneAddressing),],


### PR DESCRIPTION
## Summary
Add branch operations

## Related Issue (link)
#24 

## Testing 
```
    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.01s
     Running unittests src/lib.rs (target/debug/deps/nes_pcfim-db9772defc09d3d1)

running 37 tests
test cpu::cpu_functions::tests::test_branch_if_carry_clear_not_taken ... ok
test cpu::cpu_functions::tests::test_branch_if_carry_set_not_taken ... ok
test cpu::cpu_functions::tests::test_branch_if_equal_taken ... ok
test cpu::cpu_functions::tests::test_branch_if_carry_clear_taken ... ok
test cpu::cpu_functions::tests::test_branch_if_equal_not_taken ... ok
test cpu::cpu_functions::tests::test_branch_if_carry_set_taken ... ok
test cpu::cpu_functions::tests::test_branch_if_minus_taken ... ok
test cpu::cpu_functions::tests::test_branch_if_minus_not_taken ... ok
test cpu::cpu_functions::tests::test_branch_if_not_equal_not_taken ... ok
test cpu::cpu_functions::tests::test_branch_if_overflow_clear_taken ... ok
test cpu::cpu_functions::tests::test_branch_if_overflow_clear_not_taken ... ok
test cpu::cpu_functions::tests::test_branch_if_not_equal_taken ... ok
test cpu::cpu_functions::tests::test_branch_if_overflow_set_not_taken ... ok
test cpu::cpu_functions::tests::test_branch_if_overflow_set_taken ... ok
test cpu::cpu_functions::tests::test_branch_if_positive_taken ... ok
test cpu::cpu_functions::tests::test_compare_equal ... ok
test cpu::cpu_functions::tests::test_compare_lesser ... ok
test cpu::cpu_functions::tests::test_compare_greater ... ok
test cpu::cpu_functions::tests::test_get_operand_address_relative_negative ... ok
test cpu::cpu_functions::tests::test_get_operand_address_absolute_x ... ok
test cpu::cpu_functions::tests::test_zero_page ... ok
test cpu::cpu_functions::tests::test_branch_if_positive_not_taken ... ok
test cpu::memory::tests::test_write_u16_correct_positions ... ok
test cpu::memory::tests::test_read_write_u16 ... ok
test cpu::cpu_functions::tests::test_get_operand_address_absolute ... ok
test cpu::cpu_functions::tests::test_zero_page_x ... ok
test cpu::cpu_functions::tests::test_zero_page_y ... ok
test cpu::cpu_functions::tests::test_get_operand_address_indirect_y ... ok
test cpu::cpu_functions::tests::test_store_accumulator ... ok
test cpu::cpu_functions::tests::test_immediate ... ok
test cpu::cpu_functions::tests::test_get_operand_address_absolute_y ... ok
test cpu::cpu_functions::tests::test_get_operand_address_relative_positive ... ok
test cpu::cpu_functions::tests::test_get_operand_address_none_addressing - should panic ... ok
test cpu::cpu_functions::tests::test_transfer_accumulator_to_x ... ok
test cpu::cpu_functions::tests::test_get_operand_address_indirect_x ... ok
test cpu::cpu_functions::tests::test_increment_x_register_by_1 ... ok
test cpu::cpu_functions::tests::test_load_accumulator ... ok

test result: ok. 37 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.02s

     Running unittests src/main.rs (target/debug/deps/nes_pcfim-3fd9c6ed281c1f7f)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

   Doc-tests nes_pcfim

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
```