### PR TITLE
Add jump operations

### DIFF
--- a/src/cpu/addressing_mode.rs
+++ b/src/cpu/addressing_mode.rs
@@ -8,6 +8,7 @@ pub enum AddressingMode {
     Absolute,
     Absolute_X,
     Absolute_Y,
+    Indirect,
     Indirect_X,
     Indirect_Y,
     NoneAddressing,

--- a/src/cpu/cpu_functions.rs
+++ b/src/cpu/cpu_functions.rs
@@ -44,6 +44,19 @@ pub fn get_operand_address(cpu: &mut CPU, mode: &AddressingMode) -> u16 {
             base.wrapping_add(cpu.register_y as u16)
         }
 
+        AddressingMode::Indirect => {
+            let base = cpu.memory.read_u16(cpu.program_counter);
+            let lo = cpu.memory.memory[base as usize];
+            let hi_addr = if (base & 0xFF) == 0xFF {
+                // Bug: Wrap around within the same page instead of crossing page boundary
+                (base & 0xFF00) | ((base + 1) & 0xFF)
+            } else {
+                // Normal case: Fetch from the next sequential address
+                base.wrapping_add(1)
+            };
+            let hi: u8 = cpu.memory.memory[hi_addr as usize];
+            ((hi as u16) << 8) | (lo as u16)
+        }
         AddressingMode::Indirect_X => {
             let base = cpu.memory.memory[cpu.program_counter as usize];
 
@@ -138,6 +151,23 @@ pub fn increment_x_register(cpu: &mut CPU, _mode: &AddressingMode) {
 pub fn increment_y_register(cpu: &mut CPU, _mode: &AddressingMode) {
     cpu.register_y = cpu.register_y.wrapping_add(1);
     update_zero_and_negative_flags(cpu, cpu.register_y);
+}
+
+pub fn jump(cpu: &mut CPU, mode: &AddressingMode) {
+    let address = get_operand_address(cpu, mode);
+    cpu.program_counter = address;
+}
+
+pub fn jump_to_subroutine(cpu: &mut CPU, mode: &AddressingMode) {
+    let address: u16 = get_operand_address(cpu, mode);
+    let return_address: u16 = cpu.program_counter + 1;
+    let high: u8 = (return_address >> 8) as u8;
+    let low: u8 = (return_address & 0xFF) as u8;
+    cpu.memory.memory[(0x0100 + cpu.stack_pointer as u16) as usize] = high;
+    cpu.stack_pointer = cpu.stack_pointer.wrapping_sub(1);
+    cpu.memory.memory[(0x0100 + cpu.stack_pointer as u16) as usize] = low;
+    cpu.stack_pointer = cpu.stack_pointer.wrapping_sub(1);
+    cpu.program_counter = address;
 }
 
 pub fn decrement_memory(cpu: &mut CPU, _mode: &AddressingMode) {
@@ -426,6 +456,123 @@ mod tests {
             increment_y_register(&mut cpu, &mode);
         }
         assert_eq!(cpu.register_y, TEST_BASE_REGISTER_Y.wrapping_add(AMOUNT));
+    }
+
+    #[test]
+    fn test_jump_absolute_normal() {
+        let mut cpu = CPU::new();
+        cpu.program_counter = 0x1000;
+        cpu.memory.memory[0x1000] = 0x34;
+        cpu.memory.memory[0x1001] = 0x12;
+
+        jump(&mut cpu, &AddressingMode::Absolute);
+
+        assert_eq!(cpu.program_counter, 0x1234);
+    }
+
+    #[test]
+    fn test_jump_absolute_max_address() {
+        let mut cpu = CPU::new();
+        cpu.program_counter = 0x2000;
+        cpu.memory.memory[0x2000] = 0xFF;
+        cpu.memory.memory[0x2001] = 0xFF;
+
+        jump(&mut cpu, &AddressingMode::Absolute);
+
+        assert_eq!(cpu.program_counter, 0xFFFF);
+    }
+
+    #[test]
+    fn test_jump_indirect_normal() {
+        let mut cpu = CPU::new();
+        cpu.program_counter = 0x3000;
+        cpu.memory.memory[0x3000] = 0x50;
+        cpu.memory.memory[0x3001] = 0x40;
+        cpu.memory.memory[0x4050] = 0x78;
+        cpu.memory.memory[0x4051] = 0x56;
+
+        jump(&mut cpu, &AddressingMode::Indirect);
+
+        assert_eq!(cpu.program_counter, 0x5678);
+    }
+
+    #[test]
+    fn test_jump_indirect_page_boundary_bug() {
+        let mut cpu = CPU::new();
+        cpu.program_counter = 0x4000;
+        cpu.memory.memory[0x4000] = 0xFF;
+        cpu.memory.memory[0x4001] = 0x01;
+        cpu.memory.memory[0x01FF] = 0xCD;
+        cpu.memory.memory[0x0200] = 0xAB;
+        cpu.memory.memory[0x0100] = 0xEF;
+
+        jump(&mut cpu, &AddressingMode::Indirect);
+
+        assert_eq!(cpu.program_counter, 0xEFCD);
+    }
+
+    #[test]
+    fn test_jump_to_subroutine_normal() {
+        let mut cpu = CPU::new();
+        cpu.program_counter = 0x1001;
+        cpu.stack_pointer = 0xFF;
+        cpu.memory.memory[0x1001] = 0x34;
+        cpu.memory.memory[0x1002] = 0x12;
+
+        jump_to_subroutine(&mut cpu, &AddressingMode::Absolute);
+
+        assert_eq!(cpu.program_counter, 0x1234);
+        assert_eq!(cpu.stack_pointer, 0xFD);
+        assert_eq!(cpu.memory.memory[0x01FF], 0x10);
+        assert_eq!(cpu.memory.memory[0x01FE], 0x02);
+    }
+
+    #[test]
+    fn test_jump_to_subroutine_stack_wrap() {
+        let mut cpu = CPU::new();
+        cpu.program_counter = 0x2000;
+        cpu.stack_pointer = 0x01;
+        cpu.memory.memory[0x2000] = 0x56;
+        cpu.memory.memory[0x2001] = 0x34;
+
+        jump_to_subroutine(&mut cpu, &AddressingMode::Absolute);
+
+        assert_eq!(cpu.program_counter, 0x3456);
+        assert_eq!(cpu.stack_pointer, 0xFF);
+        assert_eq!(cpu.memory.memory[0x0101], 0x20);
+        assert_eq!(cpu.memory.memory[0x0100], 0x01);
+    }
+
+    #[test]
+    fn test_jump_to_subroutine_target_zero() {
+        let mut cpu = CPU::new();
+        cpu.program_counter = 0x3000;
+        cpu.stack_pointer = 0xFF;
+        cpu.memory.memory[0x3000] = 0x00;
+        cpu.memory.memory[0x3001] = 0x00;
+
+        jump_to_subroutine(&mut cpu, &AddressingMode::Absolute);
+
+        assert_eq!(cpu.program_counter, 0x0000);
+        assert_eq!(cpu.stack_pointer, 0xFD);
+        assert_eq!(cpu.memory.memory[0x01FF], 0x30);
+        assert_eq!(cpu.memory.memory[0x01FE], 0x01);
+    }
+
+    #[test]
+    fn test_jump_to_subroutine_target_max() {
+        let mut cpu = CPU::new();
+        cpu.program_counter = 0x4000;
+        cpu.stack_pointer = 0xFF;
+        cpu.memory.memory[0x4000] = 0xFF;
+        cpu.memory.memory[0x4001] = 0xFF;
+
+        jump_to_subroutine(&mut cpu, &AddressingMode::Absolute);
+
+        assert_eq!(cpu.program_counter, 0xFFFF);
+        assert_eq!(cpu.stack_pointer, 0xFD);
+        assert_eq!(cpu.memory.memory[0x01FF], 0x40);
+        assert_eq!(cpu.memory.memory[0x01FE], 0x01);
     }
 
     #[test]

--- a/src/cpu/operation_codes.rs
+++ b/src/cpu/operation_codes.rs
@@ -16,6 +16,8 @@ pub enum OperationName {
     IncrementMemory,
     IncrementXRegister,
     IncrementYRegister,
+    Jump,
+    JumpToSubroutine,
     LoadAccumulator,
     LoadXRegister,
     LoadYRegister,
@@ -102,6 +104,19 @@ lazy_static! {
                 Operation::new(0xfe, 3, 7, AddressingMode::Absolute_X),
             ],
             cpu_functions::increment_memory
+        ),
+        OperationCodes::new(
+            OperationName::Jump,
+            vec![
+                Operation::new(0x4c, 3, 3, AddressingMode::Absolute),
+                Operation::new(0x6c, 3, 5, AddressingMode::Indirect),
+            ],
+            cpu_functions::jump
+        ),
+        OperationCodes::new(
+            OperationName::JumpToSubroutine,
+            vec![Operation::new(0x20, 3, 6, AddressingMode::Absolute),],
+            cpu_functions::jump_to_subroutine
         ),
         OperationCodes::new(
             OperationName::DecrementXRegister,


### PR DESCRIPTION
## Summary
Add jump operations

## Related Issue (link)
#24 

## Testing 
```
    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.01s
     Running unittests src/lib.rs (target/debug/deps/nes_pcfim-db9772defc09d3d1)

running 41 tests
test cpu::cpu_functions::tests::test_compare_greater ... ok
test cpu::cpu_functions::tests::test_compare_equal ... ok
test cpu::cpu_functions::tests::test_decrement_y_register ... ok
test cpu::cpu_functions::tests::test_get_operand_address_absolute ... ok
test cpu::cpu_functions::tests::test_compare_lesser ... ok
test cpu::cpu_functions::tests::test_decrement_memory ... ok
test cpu::cpu_functions::tests::test_get_operand_address_absolute_y ... ok
test cpu::cpu_functions::tests::test_decrement_x_register ... ok
test cpu::cpu_functions::tests::test_get_operand_address_indirect_y ... ok
test cpu::cpu_functions::tests::test_get_operand_address_indirect_x ... ok
test cpu::cpu_functions::tests::test_get_operand_address_absolute_x ... ok
test cpu::cpu_functions::tests::test_immediate ... ok
test cpu::cpu_functions::tests::test_get_operand_address_none_addressing - should panic ... ok
test cpu::cpu_functions::tests::test_increment_memory ... ok
test cpu::cpu_functions::tests::test_increment_y_register ... ok
test cpu::cpu_functions::tests::test_increment_x_register ... ok
test cpu::cpu_functions::tests::test_jump_absolute_normal ... ok
test cpu::cpu_functions::tests::test_jump_absolute_max_address ... ok
test cpu::cpu_functions::tests::test_jump_to_subroutine_normal ... ok
test cpu::cpu_functions::tests::test_load_accumulator ... ok
test cpu::cpu_functions::tests::test_store_x_register ... ok
test cpu::cpu_functions::tests::test_jump_indirect_normal ... ok
test cpu::cpu_functions::tests::test_transfer_x_to_accumulator ... ok
test cpu::cpu_functions::tests::test_jump_to_subroutine_stack_wrap ... ok
test cpu::cpu_functions::tests::test_jump_to_subroutine_target_zero ... ok
test cpu::cpu_functions::tests::test_transfer_accumulator_to_x ... ok
test cpu::memory::tests::test_read_write_u16 ... ok
test cpu::cpu_functions::tests::test_transfer_y_to_accumulator ... ok
test cpu::cpu_functions::tests::test_store_accumulator ... ok
test cpu::cpu_functions::tests::test_transfer_accumulator_to_y ... ok
test cpu::cpu_functions::tests::test_jump_to_subroutine_target_max ... ok
test cpu::cpu_functions::tests::test_jump_indirect_page_boundary_bug ... ok
test cpu::cpu_functions::tests::test_store_y_register ... ok
test cpu::cpu_functions::tests::test_transfer_stack_pointer_to_x ... ok
test cpu::memory::tests::test_write_u16_correct_positions ... ok
test cpu::cpu_functions::tests::test_zero_page ... ok
test cpu::cpu_functions::tests::test_zero_page_x ... ok
test cpu::cpu_functions::tests::test_transfer_x_to_stack_pointer ... ok
test cpu::cpu_functions::tests::testing_add_with_carry ... ok
test cpu::cpu_functions::tests::test_zero_page_y ... ok
test cpu::cpu_functions::tests::testing_substract_with_carry ... ok

test result: ok. 41 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.03s

     Running unittests src/main.rs (target/debug/deps/nes_pcfim-3fd9c6ed281c1f7f)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

   Doc-tests nes_pcfim

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
```