### PR TITLE
Feat/0024 add return operations

### DIFF
--- a/src/cpu/addressing_mode.rs
+++ b/src/cpu/addressing_mode.rs
@@ -2,6 +2,7 @@
 #[allow(non_camel_case_types)]
 pub enum AddressingMode {
     Immediate,
+    Implied,
     ZeroPage,
     ZeroPage_X,
     ZeroPage_Y,

--- a/src/cpu/cpu_functions.rs
+++ b/src/cpu/cpu_functions.rs
@@ -22,6 +22,8 @@ pub fn get_operand_address(cpu: &mut CPU, mode: &AddressingMode) -> u16 {
     match mode {
         AddressingMode::Immediate => cpu.program_counter,
 
+        AddressingMode::Implied => cpu.program_counter, // TODO: Fix
+
         AddressingMode::ZeroPage => cpu.memory.memory[cpu.program_counter as usize] as u16,
 
         AddressingMode::Absolute => cpu.memory.read_u16(cpu.program_counter),
@@ -232,6 +234,22 @@ pub fn transfer_y_to_accumulator(cpu: &mut CPU, _mode: &AddressingMode) {
 
 pub fn transfer_x_to_stack_pointer(cpu: &mut CPU, _mode: &AddressingMode) {
     cpu.stack_pointer = cpu.register_x;
+}
+
+pub fn return_from_interrupt(cpu: &mut CPU, _mode: &AddressingMode) {
+    // TODO: Fix
+    let lo = cpu.memory.read_u16(cpu.stack_pointer as u16 + 1);
+    let hi = cpu.memory.read_u16(cpu.stack_pointer as u16 + 2);
+    cpu.program_counter = ((hi as u16) << 8) | (lo as u16);
+    cpu.stack_pointer += 3;
+}
+
+pub fn return_from_subroutine(cpu: &mut CPU, _mode: &AddressingMode) {
+    // TODO: Fix
+    let lo = cpu.memory.read_u16(cpu.stack_pointer as u16 + 1);
+    let hi = cpu.memory.read_u16(cpu.stack_pointer as u16 + 2);
+    cpu.program_counter = ((hi as u16) << 8) | (lo as u16);
+    cpu.stack_pointer += 2;
 }
 
 pub fn force_interruptions(_cpu: &mut CPU, _mode: &AddressingMode) {}

--- a/src/cpu/cpu_functions.rs
+++ b/src/cpu/cpu_functions.rs
@@ -237,19 +237,23 @@ pub fn transfer_x_to_stack_pointer(cpu: &mut CPU, _mode: &AddressingMode) {
 }
 
 pub fn return_from_interrupt(cpu: &mut CPU, _mode: &AddressingMode) {
-    // TODO: Fix
-    let lo = cpu.memory.read_u16(cpu.stack_pointer as u16 + 1);
-    let hi = cpu.memory.read_u16(cpu.stack_pointer as u16 + 2);
-    cpu.program_counter = ((hi as u16) << 8) | (lo as u16);
-    cpu.stack_pointer += 3;
+    cpu.stack_pointer = cpu.stack_pointer.wrapping_add(1);
+    let status = cpu.memory.memory[0x0100 + cpu.stack_pointer as usize];
+    cpu.stack_pointer = cpu.stack_pointer.wrapping_add(1);
+    let lo = cpu.memory.memory[0x0100 + cpu.stack_pointer as usize] as u16;
+    cpu.stack_pointer = cpu.stack_pointer.wrapping_add(1);
+    let hi = cpu.memory.memory[0x0100 + cpu.stack_pointer as usize] as u16;
+    cpu.program_counter = (hi << 8) | lo;
+    cpu.status = status;
 }
 
 pub fn return_from_subroutine(cpu: &mut CPU, _mode: &AddressingMode) {
-    // TODO: Fix
-    let lo = cpu.memory.read_u16(cpu.stack_pointer as u16 + 1);
-    let hi = cpu.memory.read_u16(cpu.stack_pointer as u16 + 2);
-    cpu.program_counter = ((hi as u16) << 8) | (lo as u16);
-    cpu.stack_pointer += 2;
+    cpu.stack_pointer = cpu.stack_pointer.wrapping_add(1);
+    let lo = cpu.memory.memory[0x0100 + cpu.stack_pointer as usize] as u16;
+    cpu.stack_pointer = cpu.stack_pointer.wrapping_add(1);
+    let hi = cpu.memory.memory[0x0100 + cpu.stack_pointer as usize] as u16;
+    cpu.program_counter = (hi << 8) | lo;
+    cpu.program_counter = cpu.program_counter.wrapping_add(1);
 }
 
 pub fn force_interruptions(_cpu: &mut CPU, _mode: &AddressingMode) {}
@@ -538,6 +542,49 @@ mod tests {
         let mut cpu: CPU = create_test_cpu();
         transfer_x_to_stack_pointer(&mut cpu, &AddressingMode::NoneAddressing);
         assert_eq!(cpu.stack_pointer, TEST_BASE_REGISTER_X);
+    }
+
+    #[test]
+    fn test_return_from_subroutine() {
+        let mut cpu = CPU::new();
+
+        let return_addr = 0xABCD;
+        cpu.stack_pointer = 0xFD;
+        cpu.memory.memory[0x01FE] = ((return_addr - 1) & 0xFF) as u8;
+        cpu.memory.memory[0x01FF] = ((return_addr - 1) >> 8) as u8;
+
+        return_from_subroutine(&mut cpu, &AddressingMode::Implied);
+
+        assert_eq!(
+            cpu.program_counter, return_addr,
+            "RTS should set PC to return address"
+        );
+        assert_eq!(
+            cpu.stack_pointer, 0xFF,
+            "RTS should increment SP by 2 from initial value"
+        );
+    }
+
+    #[test]
+    fn test_return_from_interrupt() {
+        let mut cpu = CPU::new();
+
+        cpu.stack_pointer = 0xFC;
+        cpu.memory.memory[0x01FD] = 0x55;
+        cpu.memory.memory[0x01FE] = 0xCD;
+        cpu.memory.memory[0x01FF] = 0xAB;
+
+        return_from_interrupt(&mut cpu, &AddressingMode::Implied);
+
+        assert_eq!(
+            cpu.program_counter, 0xABCD,
+            "RTI should set PC to popped address"
+        );
+        assert_eq!(cpu.status, 0x55, "RTI should restore status register");
+        assert_eq!(
+            cpu.stack_pointer, 0xFF,
+            "RTI should increment SP by 3 from initial value"
+        );
     }
 
     #[test]

--- a/src/cpu/operation_codes.rs
+++ b/src/cpu/operation_codes.rs
@@ -19,6 +19,8 @@ pub enum OperationName {
     LoadAccumulator,
     LoadXRegister,
     LoadYRegister,
+    ReturnFromInterrupt,
+    ReturnFromSubroutine,
     SubstractWithCarry,
     StoreAccumulator,
     StoreXRegister,
@@ -158,6 +160,16 @@ lazy_static! {
                 Operation::new(0xBC, 3, 4, AddressingMode::Absolute_X),
             ],
             cpu_functions::load_y_register
+        ),
+        OperationCodes::new(
+            OperationName::ReturnFromInterrupt,
+            vec![Operation::new(0x40, 1, 6, AddressingMode::Implied),],
+            cpu_functions::return_from_interrupt
+        ),
+        OperationCodes::new(
+            OperationName::ReturnFromSubroutine,
+            vec![Operation::new(0x60, 1, 6, AddressingMode::Implied),],
+            cpu_functions::return_from_subroutine
         ),
         OperationCodes::new(
             OperationName::StoreAccumulator,


### PR DESCRIPTION
## Summary
Add 
RTI - Return from Interrupt
RTS - Return from Subroutine

## Related Issue (link)
#24 

## Testing 
```
    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.02s
     Running unittests src/lib.rs (target/debug/deps/nes_pcfim-db9772defc09d3d1)

running 61 tests
test cpu::cpu_functions::tests::test_branch_if_carry_clear_not_taken ... ok
test cpu::cpu_functions::tests::test_branch_if_equal_not_taken ... ok
test cpu::cpu_functions::tests::test_branch_if_carry_set_taken ... ok
test cpu::cpu_functions::tests::test_branch_if_carry_clear_taken ... ok
test cpu::cpu_functions::tests::test_branch_if_minus_not_taken ... ok
test cpu::cpu_functions::tests::test_branch_if_carry_set_not_taken ... ok
test cpu::cpu_functions::tests::test_branch_if_equal_taken ... ok
test cpu::cpu_functions::tests::test_branch_if_minus_taken ... ok
test cpu::cpu_functions::tests::test_branch_if_not_equal_taken ... ok
test cpu::cpu_functions::tests::test_branch_if_not_equal_not_taken ... ok
test cpu::cpu_functions::tests::test_branch_if_overflow_clear_not_taken ... ok
test cpu::cpu_functions::tests::test_branch_if_overflow_set_taken ... ok
test cpu::cpu_functions::tests::test_branch_if_overflow_clear_taken ... ok
test cpu::cpu_functions::tests::test_branch_if_overflow_set_not_taken ... ok
test cpu::cpu_functions::tests::test_compare_equal ... ok
test cpu::cpu_functions::tests::test_branch_if_positive_taken ... ok
test cpu::cpu_functions::tests::test_branch_if_positive_not_taken ... ok
test cpu::cpu_functions::tests::test_decrement_memory ... ok
test cpu::cpu_functions::tests::test_jump_indirect_page_boundary_bug ... ok
test cpu::cpu_functions::tests::test_get_operand_address_absolute ... ok
test cpu::cpu_functions::tests::test_get_operand_address_relative_negative ... ok
test cpu::cpu_functions::tests::test_increment_y_register ... ok
test cpu::cpu_functions::tests::test_compare_lesser ... ok
test cpu::cpu_functions::tests::test_jump_to_subroutine_normal ... ok
test cpu::cpu_functions::tests::test_compare_greater ... ok
test cpu::cpu_functions::tests::test_jump_indirect_normal ... ok
test cpu::cpu_functions::tests::test_get_operand_address_indirect_y ... ok
test cpu::cpu_functions::tests::test_return_from_subroutine ... ok
test cpu::cpu_functions::tests::test_decrement_y_register ... ok
test cpu::cpu_functions::tests::test_get_operand_address_relative_positive ... ok
test cpu::cpu_functions::tests::test_jump_to_subroutine_target_max ... ok
test cpu::cpu_functions::tests::test_get_operand_address_absolute_x ... ok
test cpu::cpu_functions::tests::test_decrement_x_register ... ok
test cpu::cpu_functions::tests::test_immediate ... ok
test cpu::cpu_functions::tests::test_increment_memory ... ok
test cpu::cpu_functions::tests::test_return_from_interrupt ... ok
test cpu::cpu_functions::tests::test_store_y_register ... ok
test cpu::cpu_functions::tests::test_jump_absolute_normal ... ok
test cpu::cpu_functions::tests::test_get_operand_address_none_addressing - should panic ... ok
test cpu::cpu_functions::tests::test_transfer_stack_pointer_to_x ... ok
test cpu::memory::tests::test_read_write_u16 ... ok
test cpu::cpu_functions::tests::testing_add_with_carry ... ok
test cpu::cpu_functions::tests::test_get_operand_address_absolute_y ... ok
test cpu::cpu_functions::tests::test_get_operand_address_indirect_x ... ok
test cpu::cpu_functions::tests::test_increment_x_register ... ok
test cpu::cpu_functions::tests::test_jump_absolute_max_address ... ok
test cpu::cpu_functions::tests::test_transfer_x_to_stack_pointer ... ok
test cpu::cpu_functions::tests::test_load_accumulator ... ok
test cpu::cpu_functions::tests::test_store_x_register ... ok
test cpu::cpu_functions::tests::test_jump_to_subroutine_target_zero ... ok
test cpu::cpu_functions::tests::test_zero_page_y ... ok
test cpu::cpu_functions::tests::test_transfer_accumulator_to_x ... ok
test cpu::cpu_functions::tests::test_jump_to_subroutine_stack_wrap ... ok
test cpu::cpu_functions::tests::test_transfer_accumulator_to_y ... ok
test cpu::cpu_functions::tests::test_store_accumulator ... ok
test cpu::cpu_functions::tests::test_zero_page ... ok
test cpu::memory::tests::test_write_u16_correct_positions ... ok
test cpu::cpu_functions::tests::test_transfer_x_to_accumulator ... ok
test cpu::cpu_functions::tests::test_zero_page_x ... ok
test cpu::cpu_functions::tests::test_transfer_y_to_accumulator ... ok
test cpu::cpu_functions::tests::testing_substract_with_carry ... ok

test result: ok. 61 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.05s

     Running unittests src/main.rs (target/debug/deps/nes_pcfim-3fd9c6ed281c1f7f)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

   Doc-tests nes_pcfim

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
```