### PR TITLE
Add new cpu instructions

### DIFF
--- a/src/cpu/addressing_mode.rs
+++ b/src/cpu/addressing_mode.rs
@@ -1,6 +1,7 @@
 #[derive(Debug)]
 #[allow(non_camel_case_types)]
 pub enum AddressingMode {
+    Accumulator,
     Immediate,
     Implied,
     ZeroPage,

--- a/src/cpu/bitwise_operation.rs
+++ b/src/cpu/bitwise_operation.rs
@@ -7,7 +7,7 @@ pub enum BitwiseOperation {
 }
 
 impl BitwiseOperation {
-    pub fn from_u8(value: bool) -> Self {
+    pub fn from_bool(value: bool) -> Self {
         if value {
             BitwiseOperation::Set
         } else {

--- a/src/cpu/bitwise_operation.rs
+++ b/src/cpu/bitwise_operation.rs
@@ -5,3 +5,13 @@ pub enum BitwiseOperation {
     Unset,
     Flip,
 }
+
+impl BitwiseOperation {
+    pub fn from_u8(value: bool) -> Self {
+        if value {
+            BitwiseOperation::Set
+        } else {
+            BitwiseOperation::Unset
+        }
+    }
+}

--- a/src/cpu/cpu_functions.rs
+++ b/src/cpu/cpu_functions.rs
@@ -1493,6 +1493,16 @@ mod tests {
     }
 
     #[test]
+    fn test_rotate_right() {
+        let mut cpu = create_test_cpu();
+        cpu.memory.memory[cpu.program_counter as usize] = 0b0000_0011;
+        cpu.status = 0b0000_0001;
+        rotate_right(&mut cpu, &AddressingMode::Immediate);
+        assert_eq!(cpu.memory.memory[cpu.program_counter as usize], 0b1000_0001);
+        assert_eq!(get_bit(cpu.status, StatusBit::Carry), 1);
+    }
+
+    #[test]
     fn test_rotate_right_accumulator() {
         let mut cpu = create_test_cpu();
         cpu.register_a = 0b0000_0011;

--- a/src/cpu/cpu_functions.rs
+++ b/src/cpu/cpu_functions.rs
@@ -20,6 +20,8 @@ pub fn update_zero_and_negative_flags(cpu: &mut CPU, result: u8) {
 
 pub fn get_operand_address(cpu: &mut CPU, mode: &AddressingMode) -> u16 {
     match mode {
+        AddressingMode::Accumulator => cpu.register_a as u16,
+
         AddressingMode::Immediate => cpu.program_counter,
 
         AddressingMode::Implied => cpu.program_counter, // TODO: Fix
@@ -346,6 +348,139 @@ pub fn return_from_subroutine(cpu: &mut CPU, _mode: &AddressingMode) {
 
 pub fn force_interruptions(_cpu: &mut CPU, _mode: &AddressingMode) {}
 
+pub fn arithmetic_shift_left(cpu: &mut CPU, _mode: &AddressingMode) {
+    let address = get_operand_address(cpu, _mode);
+    let mut value = cpu.memory.memory[address as usize];
+    let carry = value >> 7;
+    value <<= 1;
+    cpu.memory.memory[address as usize] = value;
+    update_zero_and_negative_flags(cpu, value);
+    update_status_bit(cpu, StatusBit::Carry, BitwiseOperation::from_u8(carry == 1));
+}
+
+pub fn bit_test(cpu: &mut CPU, _mode: &AddressingMode) {
+    let address = get_operand_address(cpu, _mode);
+    let value = cpu.memory.memory[address as usize];
+    let result = cpu.register_a & value;
+
+    update_status_bit(cpu, StatusBit::Zero, BitwiseOperation::from_u8(result == 0));
+    update_status_bit(
+        cpu,
+        StatusBit::Overflow,
+        BitwiseOperation::from_u8((value >> 6) & 1 == 1),
+    );
+    update_status_bit(
+        cpu,
+        StatusBit::Negative,
+        BitwiseOperation::from_u8((value >> 7) & 1 == 1),
+    );
+}
+
+pub fn clear_carry_flag(cpu: &mut CPU, _mode: &AddressingMode) {
+    update_status_bit(cpu, StatusBit::Carry, BitwiseOperation::Unset);
+}
+
+pub fn clear_decimal_mode(cpu: &mut CPU, _mode: &AddressingMode) {
+    update_status_bit(cpu, StatusBit::Decimal, BitwiseOperation::Unset);
+}
+
+pub fn clear_interrupt_disable(cpu: &mut CPU, _mode: &AddressingMode) {
+    update_status_bit(cpu, StatusBit::Interrupt, BitwiseOperation::Unset);
+}
+
+pub fn clear_overflow_flag(cpu: &mut CPU, _mode: &AddressingMode) {
+    update_status_bit(cpu, StatusBit::Overflow, BitwiseOperation::Unset);
+}
+
+pub fn exclusive_or(cpu: &mut CPU, _mode: &AddressingMode) {
+    let address = get_operand_address(cpu, _mode);
+    let value = cpu.memory.memory[address as usize];
+    cpu.register_a ^= value;
+    update_zero_and_negative_flags(cpu, cpu.register_a);
+}
+
+pub fn logical_and(cpu: &mut CPU, _mode: &AddressingMode) {
+    let address = get_operand_address(cpu, _mode);
+    let value = cpu.memory.memory[address as usize];
+    cpu.register_a &= value;
+    update_zero_and_negative_flags(cpu, cpu.register_a);
+}
+
+pub fn logical_inclusive_or(cpu: &mut CPU, _mode: &AddressingMode) {
+    let address = get_operand_address(cpu, _mode);
+    let value = cpu.memory.memory[address as usize];
+    cpu.register_a |= value;
+    update_zero_and_negative_flags(cpu, cpu.register_a);
+}
+
+pub fn logical_shift_right(cpu: &mut CPU, _mode: &AddressingMode) {
+    let address = get_operand_address(cpu, _mode);
+    let mut value = cpu.memory.memory[address as usize];
+    let carry = value & 1;
+    value >>= 1;
+    cpu.memory.memory[address as usize] = value;
+    update_zero_and_negative_flags(cpu, value);
+    update_status_bit(cpu, StatusBit::Carry, BitwiseOperation::from_u8(carry == 1));
+}
+
+pub fn pull_accumulator(cpu: &mut CPU, _mode: &AddressingMode) {
+    cpu.stack_pointer = cpu.stack_pointer.wrapping_add(1);
+    let address = 0x0100 + cpu.stack_pointer as u16;
+    cpu.register_a = cpu.memory.memory[address as usize];
+    update_zero_and_negative_flags(cpu, cpu.register_a);
+}
+
+pub fn pull_processor_status(cpu: &mut CPU, _mode: &AddressingMode) {
+    cpu.stack_pointer = cpu.stack_pointer.wrapping_add(1);
+    let address = 0x0100 + cpu.stack_pointer as u16;
+    cpu.status = cpu.memory.memory[address as usize];
+}
+
+pub fn push_accumulator(cpu: &mut CPU, _mode: &AddressingMode) {
+    let address = 0x0100 + cpu.stack_pointer as u16;
+    cpu.memory.memory[address as usize] = cpu.register_a;
+    cpu.stack_pointer = cpu.stack_pointer.wrapping_sub(1);
+}
+
+pub fn push_processor_status(cpu: &mut CPU, _mode: &AddressingMode) {
+    let address = 0x0100 + cpu.stack_pointer as u16;
+    cpu.memory.memory[address as usize] = cpu.status;
+    cpu.stack_pointer = cpu.stack_pointer.wrapping_sub(1);
+}
+
+pub fn rotate_left(cpu: &mut CPU, _mode: &AddressingMode) {
+    let address = get_operand_address(cpu, _mode);
+    let mut value = cpu.memory.memory[address as usize];
+    let carry = value >> 7;
+    value <<= 1;
+    value |= carry;
+    cpu.memory.memory[address as usize] = value;
+    update_zero_and_negative_flags(cpu, value);
+    update_status_bit(cpu, StatusBit::Carry, BitwiseOperation::from_u8(carry == 1));
+}
+
+pub fn rotate_right(cpu: &mut CPU, _mode: &AddressingMode) {
+    let address = get_operand_address(cpu, _mode);
+    let mut value = cpu.memory.memory[address as usize];
+    let carry = value & 1;
+    value >>= 1;
+    value |= carry << 7;
+    cpu.memory.memory[address as usize] = value;
+    update_zero_and_negative_flags(cpu, value);
+    update_status_bit(cpu, StatusBit::Carry, BitwiseOperation::from_u8(carry == 1));
+}
+
+pub fn set_carry_flag(cpu: &mut CPU, _mode: &AddressingMode) {
+    update_status_bit(cpu, StatusBit::Carry, BitwiseOperation::Set);
+}
+
+pub fn set_decimal_flag(cpu: &mut CPU, _mode: &AddressingMode) {
+    update_status_bit(cpu, StatusBit::Decimal, BitwiseOperation::Set);
+}
+
+pub fn set_interrupt_disable(cpu: &mut CPU, _mode: &AddressingMode) {
+    update_status_bit(cpu, StatusBit::Interrupt, BitwiseOperation::Set);
+}
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1164,5 +1299,92 @@ mod tests {
                 testing_parameters.7
             );
         }
+    }
+
+    #[test]
+    fn test_arithmetic_shift_left() {
+        let mut cpu = create_test_cpu();
+        cpu.memory.memory[cpu.program_counter as usize] = 0b0100_0001;
+        arithmetic_shift_left(&mut cpu, &AddressingMode::Immediate);
+        assert_eq!(cpu.memory.memory[cpu.program_counter as usize], 0b1000_0010);
+        assert!(cpu.status & (StatusBit::Carry as u8) == 0);
+        assert!(cpu.status & (StatusBit::Negative as u8) == 0);
+        assert!(cpu.status & (StatusBit::Zero as u8) == 0);
+    }
+
+    #[test]
+    fn test_bit_test() {
+        let mut cpu = create_test_cpu();
+
+        cpu.register_a = 0b0000_0101;
+        cpu.memory.memory[cpu.program_counter as usize] = 0b1100_0000;
+        let mode = AddressingMode::Immediate;
+
+        bit_test(&mut cpu, &mode);
+        assert_eq!(get_bit(cpu.status, StatusBit::Zero), 1);
+        assert_eq!(get_bit(cpu.status, StatusBit::Overflow), 1);
+        assert_eq!(get_bit(cpu.status, StatusBit::Negative), 1);
+    }
+
+    #[test]
+    fn test_clear_carry_flag() {
+        let mut cpu = create_test_cpu();
+        cpu.status = 0b0000_0001;
+        clear_carry_flag(&mut cpu, &AddressingMode::NoneAddressing);
+        assert_eq!(cpu.status, 0b0000_0000);
+    }
+
+    #[test]
+    fn test_exclusive_or() {
+        let mut cpu = create_test_cpu();
+        cpu.register_a = 0b1010_1010;
+        cpu.memory.memory[cpu.program_counter as usize] = 0b1100_1100;
+        exclusive_or(&mut cpu, &AddressingMode::Immediate);
+        assert_eq!(cpu.register_a, 0b0110_0110);
+    }
+
+    #[test]
+    fn test_logical_and() {
+        let mut cpu = create_test_cpu();
+        cpu.register_a = 0b1010_1010;
+        cpu.memory.memory[cpu.program_counter as usize] = 0b1100_1100;
+        logical_and(&mut cpu, &AddressingMode::Immediate);
+        assert_eq!(cpu.register_a, 0b1000_1000);
+    }
+
+    #[test]
+    fn test_logical_inclusive_or() {
+        let mut cpu = create_test_cpu();
+        cpu.register_a = 0b1010_1010;
+        cpu.memory.memory[cpu.program_counter as usize] = 0b1100_1100;
+        logical_inclusive_or(&mut cpu, &AddressingMode::Immediate);
+        assert_eq!(cpu.register_a, 0b1110_1110);
+    }
+
+    #[test]
+    fn test_logical_shift_right() {
+        let mut cpu = create_test_cpu();
+        cpu.memory.memory[cpu.program_counter as usize] = 0b1000_0001;
+        logical_shift_right(&mut cpu, &AddressingMode::Immediate);
+        assert_eq!(cpu.memory.memory[cpu.program_counter as usize], 0b0100_0000);
+        assert_eq!(get_bit(cpu.status, StatusBit::Carry), 1);
+        assert_eq!(get_bit(cpu.status, StatusBit::Zero), 0);
+        assert_eq!(get_bit(cpu.status, StatusBit::Negative), 0);
+    }
+
+    #[test]
+    fn test_rotate_left() {
+        let mut cpu = create_test_cpu();
+        cpu.memory.memory[cpu.program_counter as usize] = 0b1000_0001;
+        rotate_left(&mut cpu, &AddressingMode::Immediate);
+        assert_eq!(cpu.memory.memory[cpu.program_counter as usize], 0b0000_0011);
+    }
+
+    #[test]
+    fn test_rotate_right() {
+        let mut cpu = create_test_cpu();
+        cpu.memory.memory[cpu.program_counter as usize] = 0b1000_0001;
+        rotate_right(&mut cpu, &AddressingMode::Immediate);
+        assert_eq!(cpu.memory.memory[cpu.program_counter as usize], 0b1100_0000);
     }
 }

--- a/src/cpu/cpu_functions.rs
+++ b/src/cpu/cpu_functions.rs
@@ -355,7 +355,11 @@ pub fn arithmetic_shift_left(cpu: &mut CPU, _mode: &AddressingMode) {
     value <<= 1;
     cpu.memory.memory[address as usize] = value;
     update_zero_and_negative_flags(cpu, value);
-    update_status_bit(cpu, StatusBit::Carry, BitwiseOperation::from_u8(carry == 1));
+    update_status_bit(
+        cpu,
+        StatusBit::Carry,
+        BitwiseOperation::from_bool(carry == 1),
+    );
 }
 
 pub fn bit_test(cpu: &mut CPU, _mode: &AddressingMode) {
@@ -363,16 +367,20 @@ pub fn bit_test(cpu: &mut CPU, _mode: &AddressingMode) {
     let value = cpu.memory.memory[address as usize];
     let result = cpu.register_a & value;
 
-    update_status_bit(cpu, StatusBit::Zero, BitwiseOperation::from_u8(result == 0));
+    update_status_bit(
+        cpu,
+        StatusBit::Zero,
+        BitwiseOperation::from_bool(result == 0),
+    );
     update_status_bit(
         cpu,
         StatusBit::Overflow,
-        BitwiseOperation::from_u8((value >> 6) & 1 == 1),
+        BitwiseOperation::from_bool((value >> 6) & 1 == 1),
     );
     update_status_bit(
         cpu,
         StatusBit::Negative,
-        BitwiseOperation::from_u8((value >> 7) & 1 == 1),
+        BitwiseOperation::from_bool((value >> 7) & 1 == 1),
     );
 }
 
@@ -420,7 +428,11 @@ pub fn logical_shift_right(cpu: &mut CPU, _mode: &AddressingMode) {
     value >>= 1;
     cpu.memory.memory[address as usize] = value;
     update_zero_and_negative_flags(cpu, value);
-    update_status_bit(cpu, StatusBit::Carry, BitwiseOperation::from_u8(carry == 1));
+    update_status_bit(
+        cpu,
+        StatusBit::Carry,
+        BitwiseOperation::from_bool(carry == 1),
+    );
 }
 
 pub fn pull_accumulator(cpu: &mut CPU, _mode: &AddressingMode) {
@@ -456,7 +468,11 @@ pub fn rotate_left(cpu: &mut CPU, _mode: &AddressingMode) {
     value |= carry;
     cpu.memory.memory[address as usize] = value;
     update_zero_and_negative_flags(cpu, value);
-    update_status_bit(cpu, StatusBit::Carry, BitwiseOperation::from_u8(carry == 1));
+    update_status_bit(
+        cpu,
+        StatusBit::Carry,
+        BitwiseOperation::from_bool(carry == 1),
+    );
 }
 
 pub fn rotate_right(cpu: &mut CPU, _mode: &AddressingMode) {
@@ -467,7 +483,11 @@ pub fn rotate_right(cpu: &mut CPU, _mode: &AddressingMode) {
     value |= carry << 7;
     cpu.memory.memory[address as usize] = value;
     update_zero_and_negative_flags(cpu, value);
-    update_status_bit(cpu, StatusBit::Carry, BitwiseOperation::from_u8(carry == 1));
+    update_status_bit(
+        cpu,
+        StatusBit::Carry,
+        BitwiseOperation::from_bool(carry == 1),
+    );
 }
 
 pub fn set_carry_flag(cpu: &mut CPU, _mode: &AddressingMode) {

--- a/src/cpu/operation_codes.rs
+++ b/src/cpu/operation_codes.rs
@@ -6,20 +6,27 @@ use std::collections::HashMap;
 
 pub enum OperationName {
     AddWithCarry,
+    ArithmeticShiftLeft,
+    BitTest,
     BranchIfCarryClear,
     BranchIfCarrySet,
     BranchIfEqual,
     BranchIfMinus,
     BranchIfNotEqual,
-    BranchIfPositive,
     BranchIfOverflowClear,
     BranchIfOverflowSet,
+    BranchIfPositive,
+    ClearCarryFlag,
+    ClearDecimalMode,
+    ClearInterruptDisable,
+    ClearOverflowFlag,
     Compare,
     CompareX,
     CompareY,
     DecrementMemory,
     DecrementXRegister,
     DecrementYRegister,
+    ExclusiveOR,
     ForceInterrupt,
     IncrementMemory,
     IncrementXRegister,
@@ -29,12 +36,24 @@ pub enum OperationName {
     LoadAccumulator,
     LoadXRegister,
     LoadYRegister,
+    LogicalAND,
+    LogicalInclusiveOR,
+    LogicalShiftRight,
+    PullAccumulator,
+    PullProcessorStatus,
+    PushAccumulator,
+    PushProcessorStatus,
     ReturnFromInterrupt,
     ReturnFromSubroutine,
-    SubstractWithCarry,
+    RotateLeft,
+    RotateRight,
+    SetCarryFlag,
+    SetDecimalFlag,
+    SetInterruptDisable,
     StoreAccumulator,
     StoreXRegister,
     StoreYRegister,
+    SubstractWithCarry,
     TransferAccumulatorToX,
     TransferAccumulatorToY,
     TransferStackPointerToX,
@@ -344,6 +363,155 @@ lazy_static! {
             OperationName::TransferYToAccumulator,
             vec![Operation::new(0x98, 1, 2, AddressingMode::NoneAddressing),],
             cpu_functions::transfer_y_to_accumulator
+        ),
+        OperationCodes::new(
+            OperationName::ArithmeticShiftLeft,
+            vec![
+                Operation::new(0x0a, 1, 2, AddressingMode::Accumulator),
+                Operation::new(0x06, 2, 5, AddressingMode::ZeroPage),
+                Operation::new(0x16, 2, 6, AddressingMode::ZeroPage_X),
+                Operation::new(0x0e, 3, 6, AddressingMode::Absolute),
+                Operation::new(0x1e, 3, 7, AddressingMode::Absolute_X),
+            ],
+            cpu_functions::arithmetic_shift_left
+        ),
+        OperationCodes::new(
+            OperationName::BitTest,
+            vec![
+                Operation::new(0x24, 2, 3, AddressingMode::ZeroPage),
+                Operation::new(0x2c, 3, 4, AddressingMode::Absolute),
+            ],
+            cpu_functions::bit_test
+        ),
+        OperationCodes::new(
+            OperationName::ClearCarryFlag,
+            vec![Operation::new(0x18, 1, 2, AddressingMode::Implied),],
+            cpu_functions::clear_carry_flag
+        ),
+        OperationCodes::new(
+            OperationName::ClearDecimalMode,
+            vec![Operation::new(0xd8, 1, 2, AddressingMode::Implied),],
+            cpu_functions::clear_decimal_mode
+        ),
+        OperationCodes::new(
+            OperationName::ClearInterruptDisable,
+            vec![Operation::new(0x58, 1, 2, AddressingMode::Implied),],
+            cpu_functions::clear_interrupt_disable
+        ),
+        OperationCodes::new(
+            OperationName::ClearOverflowFlag,
+            vec![Operation::new(0xb8, 1, 2, AddressingMode::Implied),],
+            cpu_functions::clear_overflow_flag
+        ),
+        OperationCodes::new(
+            OperationName::ExclusiveOR,
+            vec![
+                Operation::new(0x49, 2, 2, AddressingMode::Immediate),
+                Operation::new(0x45, 2, 3, AddressingMode::ZeroPage),
+                Operation::new(0x55, 2, 4, AddressingMode::ZeroPage_X),
+                Operation::new(0x4d, 3, 4, AddressingMode::Absolute),
+                Operation::new(0x5d, 3, 4, AddressingMode::Absolute_X),
+                Operation::new(0x59, 3, 4, AddressingMode::Absolute_Y),
+                Operation::new(0x41, 2, 6, AddressingMode::Indirect_X),
+                Operation::new(0x51, 2, 5, AddressingMode::Indirect_Y),
+            ],
+            cpu_functions::exclusive_or
+        ),
+        OperationCodes::new(
+            OperationName::LogicalAND,
+            vec![
+                Operation::new(0x29, 2, 2, AddressingMode::Immediate),
+                Operation::new(0x25, 2, 3, AddressingMode::ZeroPage),
+                Operation::new(0x35, 2, 4, AddressingMode::ZeroPage_X),
+                Operation::new(0x2d, 3, 4, AddressingMode::Absolute),
+                Operation::new(0x3d, 3, 4, AddressingMode::Absolute_X),
+                Operation::new(0x39, 3, 4, AddressingMode::Absolute_Y),
+                Operation::new(0x21, 2, 6, AddressingMode::Indirect_X),
+                Operation::new(0x31, 2, 5, AddressingMode::Indirect_Y),
+            ],
+            cpu_functions::logical_and
+        ),
+        OperationCodes::new(
+            OperationName::LogicalInclusiveOR,
+            vec![
+                Operation::new(0x09, 2, 2, AddressingMode::Immediate),
+                Operation::new(0x05, 2, 3, AddressingMode::ZeroPage),
+                Operation::new(0x15, 2, 4, AddressingMode::ZeroPage_X),
+                Operation::new(0x0d, 3, 4, AddressingMode::Absolute),
+                Operation::new(0x1d, 3, 4, AddressingMode::Absolute_X),
+                Operation::new(0x19, 3, 4, AddressingMode::Absolute_Y),
+                Operation::new(0x01, 2, 6, AddressingMode::Indirect_X),
+                Operation::new(0x11, 2, 5, AddressingMode::Indirect_Y),
+            ],
+            cpu_functions::logical_inclusive_or
+        ),
+        OperationCodes::new(
+            OperationName::LogicalShiftRight,
+            vec![
+                Operation::new(0x4a, 1, 2, AddressingMode::Accumulator),
+                Operation::new(0x46, 2, 5, AddressingMode::ZeroPage),
+                Operation::new(0x56, 2, 6, AddressingMode::ZeroPage_X),
+                Operation::new(0x4e, 3, 6, AddressingMode::Absolute),
+                Operation::new(0x5e, 3, 7, AddressingMode::Absolute_X),
+            ],
+            cpu_functions::logical_shift_right
+        ),
+        OperationCodes::new(
+            OperationName::PullAccumulator,
+            vec![Operation::new(0x68, 1, 4, AddressingMode::Implied),],
+            cpu_functions::pull_accumulator
+        ),
+        OperationCodes::new(
+            OperationName::PullProcessorStatus,
+            vec![Operation::new(0x28, 1, 4, AddressingMode::Implied),],
+            cpu_functions::pull_processor_status
+        ),
+        OperationCodes::new(
+            OperationName::PushAccumulator,
+            vec![Operation::new(0x48, 1, 3, AddressingMode::Implied),],
+            cpu_functions::push_accumulator
+        ),
+        OperationCodes::new(
+            OperationName::PushProcessorStatus,
+            vec![Operation::new(0x08, 1, 3, AddressingMode::Implied),],
+            cpu_functions::push_processor_status
+        ),
+        OperationCodes::new(
+            OperationName::RotateLeft,
+            vec![
+                Operation::new(0x2a, 1, 2, AddressingMode::Accumulator),
+                Operation::new(0x26, 2, 5, AddressingMode::ZeroPage),
+                Operation::new(0x36, 2, 6, AddressingMode::ZeroPage_X),
+                Operation::new(0x2e, 3, 6, AddressingMode::Absolute),
+                Operation::new(0x3e, 3, 7, AddressingMode::Absolute_X),
+            ],
+            cpu_functions::rotate_left
+        ),
+        OperationCodes::new(
+            OperationName::RotateRight,
+            vec![
+                Operation::new(0x6a, 1, 2, AddressingMode::Accumulator),
+                Operation::new(0x66, 2, 5, AddressingMode::ZeroPage),
+                Operation::new(0x76, 2, 6, AddressingMode::ZeroPage_X),
+                Operation::new(0x6e, 3, 6, AddressingMode::Absolute),
+                Operation::new(0x7e, 3, 7, AddressingMode::Absolute_X),
+            ],
+            cpu_functions::rotate_right
+        ),
+        OperationCodes::new(
+            OperationName::SetCarryFlag,
+            vec![Operation::new(0x38, 1, 2, AddressingMode::Implied),],
+            cpu_functions::set_carry_flag
+        ),
+        OperationCodes::new(
+            OperationName::SetDecimalFlag,
+            vec![Operation::new(0xf8, 1, 2, AddressingMode::Implied),],
+            cpu_functions::set_decimal_flag
+        ),
+        OperationCodes::new(
+            OperationName::SetInterruptDisable,
+            vec![Operation::new(0x78, 1, 2, AddressingMode::Implied),],
+            cpu_functions::set_interrupt_disable
         )
     ];
     pub static ref OPERATION_CODES_MAP: HashMap<u8, (&'static Operation, ExecuteFunction)> = {

--- a/src/cpu/operation_codes.rs
+++ b/src/cpu/operation_codes.rs
@@ -367,13 +367,17 @@ lazy_static! {
         OperationCodes::new(
             OperationName::ArithmeticShiftLeft,
             vec![
-                Operation::new(0x0a, 1, 2, AddressingMode::Accumulator),
                 Operation::new(0x06, 2, 5, AddressingMode::ZeroPage),
                 Operation::new(0x16, 2, 6, AddressingMode::ZeroPage_X),
                 Operation::new(0x0e, 3, 6, AddressingMode::Absolute),
                 Operation::new(0x1e, 3, 7, AddressingMode::Absolute_X),
             ],
             cpu_functions::arithmetic_shift_left
+        ),
+        OperationCodes::new(
+            OperationName::ArithmeticShiftLeft,
+            vec![Operation::new(0x0a, 1, 2, AddressingMode::Accumulator)],
+            cpu_functions::arithmetic_shift_left_accumulator
         ),
         OperationCodes::new(
             OperationName::BitTest,
@@ -448,13 +452,17 @@ lazy_static! {
         OperationCodes::new(
             OperationName::LogicalShiftRight,
             vec![
-                Operation::new(0x4a, 1, 2, AddressingMode::Accumulator),
                 Operation::new(0x46, 2, 5, AddressingMode::ZeroPage),
                 Operation::new(0x56, 2, 6, AddressingMode::ZeroPage_X),
                 Operation::new(0x4e, 3, 6, AddressingMode::Absolute),
                 Operation::new(0x5e, 3, 7, AddressingMode::Absolute_X),
             ],
             cpu_functions::logical_shift_right
+        ),
+        OperationCodes::new(
+            OperationName::LogicalShiftRight,
+            vec![Operation::new(0x4a, 1, 2, AddressingMode::Accumulator)],
+            cpu_functions::logical_shift_right_accumulator
         ),
         OperationCodes::new(
             OperationName::PullAccumulator,
@@ -479,7 +487,6 @@ lazy_static! {
         OperationCodes::new(
             OperationName::RotateLeft,
             vec![
-                Operation::new(0x2a, 1, 2, AddressingMode::Accumulator),
                 Operation::new(0x26, 2, 5, AddressingMode::ZeroPage),
                 Operation::new(0x36, 2, 6, AddressingMode::ZeroPage_X),
                 Operation::new(0x2e, 3, 6, AddressingMode::Absolute),
@@ -488,15 +495,24 @@ lazy_static! {
             cpu_functions::rotate_left
         ),
         OperationCodes::new(
+            OperationName::RotateLeft,
+            vec![Operation::new(0x2a, 1, 2, AddressingMode::Accumulator)],
+            cpu_functions::rotate_left_accumulator
+        ),
+        OperationCodes::new(
             OperationName::RotateRight,
             vec![
-                Operation::new(0x6a, 1, 2, AddressingMode::Accumulator),
                 Operation::new(0x66, 2, 5, AddressingMode::ZeroPage),
                 Operation::new(0x76, 2, 6, AddressingMode::ZeroPage_X),
                 Operation::new(0x6e, 3, 6, AddressingMode::Absolute),
                 Operation::new(0x7e, 3, 7, AddressingMode::Absolute_X),
             ],
             cpu_functions::rotate_right
+        ),
+        OperationCodes::new(
+            OperationName::RotateRight,
+            vec![Operation::new(0x6a, 1, 2, AddressingMode::Accumulator)],
+            cpu_functions::rotate_right_accumulator
         ),
         OperationCodes::new(
             OperationName::SetCarryFlag,


### PR DESCRIPTION
## Summary
Add following instructions

- AND
- EOR
- ORA
- ASL
- LSR
- ROL
- ROR
- BIT
- PHA
- PLA
- PHP
- PLP
- CLC
- CLD
- CLI
- CLV
- SEC
- SED
- SEI

## Related Issue (link)
[Remaining CPU instructions - Part 2 #23
](https://github.com/pcfim/nes-pcfim/issues/23)

## Testing 
`cargo test`

## Additional Notes
This should be the final set of instructions