### PR TITLE
Add joypads emulation (pending to finish bus)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@
 
 [dependencies]
     lazy_static = "1.4.0"
-    bitflags = "1.2.1"
+    bitflags = "2.9.0"
 
     sdl2 = "0.37.0"
     rand = "=0.7.3"

--- a/src/joypads/joypad.rs
+++ b/src/joypads/joypad.rs
@@ -1,0 +1,82 @@
+use crate::joypads::joypad_model::{Joypad, JoypadButton};
+
+impl Default for Joypad {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Joypad {
+    pub fn new() -> Self {
+        Joypad {
+            strobe: false,
+            button_index: 0,
+            button_status: JoypadButton::from_bits_truncate(0),
+        }
+    }
+
+    pub fn write(&mut self, data: u8) {
+        self.strobe = data & 1 == 1;
+        if self.strobe {
+            self.button_index = 0
+        }
+    }
+
+    pub fn read(&mut self) -> u8 {
+        if self.button_index > 7 {
+            return 1;
+        }
+        let response = (self.button_status.bits() & (1 << self.button_index)) >> self.button_index;
+        if !self.strobe && self.button_index <= 7 {
+            self.button_index += 1;
+        }
+        response
+    }
+
+    pub fn set_button_pressed_status(&mut self, button: JoypadButton, pressed: bool) {
+        self.button_status.set(button, pressed);
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_strobe_mode() {
+        let mut joypad = Joypad::new();
+        joypad.write(1);
+        joypad.set_button_pressed_status(JoypadButton::BUTTON_A, true);
+        for _x in 0..10 {
+            assert_eq!(joypad.read(), 1);
+        }
+    }
+
+    #[test]
+    fn test_strobe_mode_on_off() {
+        let mut joypad = Joypad::new();
+
+        joypad.write(0);
+        joypad.set_button_pressed_status(JoypadButton::RIGHT, true);
+        joypad.set_button_pressed_status(JoypadButton::LEFT, true);
+        joypad.set_button_pressed_status(JoypadButton::SELECT, true);
+        joypad.set_button_pressed_status(JoypadButton::BUTTON_B, true);
+
+        for _ in 0..=1 {
+            assert_eq!(joypad.read(), 0);
+            assert_eq!(joypad.read(), 1);
+            assert_eq!(joypad.read(), 1);
+            assert_eq!(joypad.read(), 0);
+            assert_eq!(joypad.read(), 0);
+            assert_eq!(joypad.read(), 0);
+            assert_eq!(joypad.read(), 1);
+            assert_eq!(joypad.read(), 1);
+
+            for _x in 0..10 {
+                assert_eq!(joypad.read(), 1);
+            }
+            joypad.write(1);
+            joypad.write(0);
+        }
+    }
+}

--- a/src/joypads/joypad_model.rs
+++ b/src/joypads/joypad_model.rs
@@ -1,0 +1,21 @@
+use bitflags::bitflags;
+
+bitflags! {
+    // https://wiki.nesdev.com/w/index.php/Controller_reading_code
+    pub struct JoypadButton: u8 {
+        const RIGHT             = 0b10000000;
+        const LEFT              = 0b01000000;
+        const DOWN              = 0b00100000;
+        const UP                = 0b00010000;
+        const START             = 0b00001000;
+        const SELECT            = 0b00000100;
+        const BUTTON_B          = 0b00000010;
+        const BUTTON_A          = 0b00000001;
+    }
+}
+
+pub struct Joypad {
+    pub strobe: bool,
+    pub button_index: u8,
+    pub button_status: JoypadButton,
+}

--- a/src/joypads/mod.rs
+++ b/src/joypads/mod.rs
@@ -1,0 +1,2 @@
+pub mod joypad;
+pub mod joypad_model;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,2 +1,3 @@
 pub mod bus;
 pub mod cpu;
+pub mod joypads;

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,12 +2,15 @@ use std::env;
 
 use nes_pcfim::cpu::cpu_instructions::Mem;
 use nes_pcfim::cpu::cpu_model::CPU;
+use nes_pcfim::joypads::joypad_model::JoypadButton;
+
 use rand::Rng;
 use sdl2::event::Event;
 use sdl2::keyboard::Keycode;
 use sdl2::pixels::Color;
 use sdl2::pixels::PixelFormatEnum;
 use sdl2::EventPump;
+use std::collections::HashMap;
 
 fn handle_user_input(cpu: &mut CPU, event_pump: &mut EventPump) {
     for event in event_pump.poll_iter() {
@@ -77,6 +80,16 @@ fn read_screen_state(cpu: &CPU, frame: &mut [u8; 32 * 3 * 32]) -> bool {
 }
 
 fn main() {
+    let mut key_map = HashMap::new();
+    key_map.insert(Keycode::Down, JoypadButton::DOWN);
+    key_map.insert(Keycode::Up, JoypadButton::UP);
+    key_map.insert(Keycode::Right, JoypadButton::RIGHT);
+    key_map.insert(Keycode::Left, JoypadButton::LEFT);
+    key_map.insert(Keycode::Space, JoypadButton::SELECT);
+    key_map.insert(Keycode::Return, JoypadButton::START);
+    key_map.insert(Keycode::A, JoypadButton::BUTTON_A);
+    key_map.insert(Keycode::S, JoypadButton::BUTTON_B);
+
     let game_code = vec![
         0x20, 0x06, 0x06, 0x20, 0x38, 0x06, 0x20, 0x0d, 0x06, 0x20, 0x2a, 0x06, 0x60, 0xa9, 0x02,
         0x85, 0x02, 0xa9, 0x04, 0x85, 0x03, 0xa9, 0x11, 0x85, 0x10, 0xa9, 0x10, 0x85, 0x12, 0xa9,


### PR DESCRIPTION
## Summary
Add joypads emulation

## Related Issue (link)
#35 

## Testing 
```
    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.15s
     Running unittests src/lib.rs (target/debug/deps/nes_pcfim-7830f80b111ef691)

running 76 tests
test cpu::cpu_functions::tests::test_bit_test ... ok
test cpu::cpu_functions::tests::test_branch_if_carry_set_not_taken ... ok
test cpu::cpu_functions::tests::test_arithmetic_shift_left_acumulator ... ok
test cpu::cpu_functions::tests::test_branch_if_minus_not_taken ... ok
test cpu::cpu_functions::tests::test_arithmetic_shift_left ... ok
test cpu::cpu_functions::tests::test_branch_if_not_equal_not_taken ... ok
test cpu::cpu_functions::tests::test_branch_if_carry_clear_taken ... ok
test cpu::cpu_functions::tests::test_branch_if_carry_set_taken ... ok
test cpu::cpu_functions::tests::test_branch_if_minus_taken ... ok
test cpu::cpu_functions::tests::test_branch_if_equal_not_taken ... ok
test cpu::cpu_functions::tests::test_branch_if_equal_taken ... ok
test cpu::cpu_functions::tests::test_branch_if_carry_clear_not_taken ... ok
test cpu::cpu_functions::tests::test_branch_if_not_equal_taken ... ok
test cpu::cpu_functions::tests::test_branch_if_overflow_clear_not_taken ... ok
test cpu::cpu_functions::tests::test_branch_if_overflow_clear_taken ... ok
test cpu::cpu_functions::tests::test_branch_if_overflow_set_not_taken ... ok
test cpu::cpu_functions::tests::test_branch_if_positive_not_taken ... ok
test cpu::cpu_functions::tests::test_get_operand_address_absolute ... ok
test cpu::cpu_functions::tests::test_branch_if_overflow_set_taken ... ok
test cpu::cpu_functions::tests::test_decrement_x_register ... ok
test cpu::cpu_functions::tests::test_compare_lesser ... ok
test cpu::cpu_functions::tests::test_compare_equal ... ok
test cpu::cpu_functions::tests::test_get_operand_address_relative_positive ... ok
test cpu::cpu_functions::tests::test_get_operand_address_indirect_x ... ok
test cpu::cpu_functions::tests::test_branch_if_positive_taken ... ok
test cpu::cpu_functions::tests::test_clear_carry_flag ... ok
test cpu::cpu_functions::tests::test_compare_greater ... ok
test cpu::cpu_functions::tests::test_jump_to_subroutine_normal ... ok
test cpu::cpu_functions::tests::test_jump_to_subroutine_target_max ... ok
test cpu::cpu_functions::tests::test_get_operand_address_indirect_y ... ok
test cpu::cpu_functions::tests::test_logical_and ... ok
test cpu::cpu_functions::tests::test_jump_to_subroutine_target_zero ... ok
test cpu::cpu_functions::tests::test_logical_inclusive_or ... ok
test cpu::cpu_functions::tests::test_jump_indirect_normal ... ok
test cpu::cpu_functions::tests::test_exclusive_or ... ok
test cpu::cpu_functions::tests::test_logical_shift_right ... ok
test cpu::cpu_functions::tests::test_mini_program ... ok
test cpu::cpu_functions::tests::test_get_operand_address_none_addressing - should panic ... ok
test cpu::cpu_functions::tests::test_rotate_right ... ok
test cpu::cpu_functions::tests::test_get_operand_address_absolute_x ... ok
test cpu::cpu_functions::tests::test_jump_to_subroutine_stack_wrap ... ok
test cpu::cpu_functions::tests::test_return_from_subroutine ... ok
test cpu::cpu_functions::tests::test_jump_absolute_normal ... ok
test cpu::cpu_functions::tests::test_jump_absolute_max_address ... ok
test cpu::cpu_functions::tests::test_get_operand_address_absolute_y ... ok
test cpu::cpu_functions::tests::test_transfer_accumulator_to_x ... ok
test cpu::cpu_functions::tests::test_jump_indirect_page_boundary_bug ... ok
test cpu::cpu_functions::tests::test_decrement_y_register ... ok
test cpu::cpu_functions::tests::test_get_operand_address_relative_negative ... ok
test cpu::cpu_functions::tests::test_increment_y_register ... ok
test cpu::cpu_functions::tests::test_immediate ... ok
test cpu::cpu_functions::tests::test_load_accumulator ... ok
test cpu::cpu_functions::tests::test_increment_x_register ... ok
test cpu::cpu_functions::tests::test_return_from_interrupt ... ok
test cpu::cpu_functions::tests::testing_add_with_carry ... ok
test cpu::cpu_functions::tests::test_zero_page_y ... ok
test cpu::cpu_functions::tests::testing_substract_with_carry ... ok
test cpu::cpu_functions::tests::test_transfer_accumulator_to_y ... ok
test joypads::joypad::test::test_strobe_mode_on_off ... ok
test cpu::cpu_functions::tests::test_rotate_left ... ok
test cpu::cpu_functions::tests::test_rotate_left_accumulator ... ok
test cpu::cpu_functions::tests::test_logical_shift_right_accumulator ... ok
test cpu::cpu_functions::tests::test_store_y_register ... ok
test cpu::cpu_functions::tests::test_store_accumulator ... ok
test cpu::cpu_functions::tests::test_transfer_stack_pointer_to_x ... ok
test joypads::joypad::test::test_strobe_mode ... ok
test cpu::cpu_functions::tests::test_store_x_register ... ok
test cpu::cpu_functions::tests::test_rotate_right_accumulator ... ok
test cpu::cpu_functions::tests::test_transfer_x_to_accumulator ... ok
test cpu::cpu_functions::tests::test_zero_page_x ... ok
test cpu::cpu_functions::tests::test_transfer_y_to_accumulator ... ok
test cpu::cpu_instructions::test_branch_operations ... ok
test cpu::cpu_functions::tests::test_transfer_x_to_stack_pointer ... ok
test cpu::cpu_functions::tests::test_zero_page ... ok
test cpu::cpu_functions::tests::testing_standalone ... ok
test cpu::cpu_functions::tests::testing_individual_opcodes has been running for over 60 seconds
test cpu::cpu_functions::tests::testing_individual_opcodes ... ok

test result: ok. 76 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 90.54s

     Running unittests src/main.rs (target/debug/deps/nes_pcfim-f80ed85f75136902)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

   Doc-tests nes_pcfim

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
```

## Additional Notes
Pending to finish after bus implementation